### PR TITLE
vertical alignment hide watched checkbox

### DIFF
--- a/subs.css
+++ b/subs.css
@@ -50,6 +50,6 @@
   cursor: pointer;
 }
 
-input {
+#osasoft-better-subscriptions_subs-grid {
     vertical-align: -3px;
 }

--- a/subs.css
+++ b/subs.css
@@ -49,3 +49,7 @@
   opacity: 1.0;
   cursor: pointer;
 }
+
+input {
+    vertical-align: -3px;
+}


### PR DESCRIPTION
The Text for the Hide watched checkbox does not line up with the Mark all as Watched Text.

I tried to fix this, it's not perfect (the checkbox probably needs to be half a pixel higher or something) but its better. I'm not sure if this solution works across different browsers it's just the easiest change that worked for me.

before:
![before](https://user-images.githubusercontent.com/1804541/45972885-3afd0a80-c03d-11e8-83fa-353e7948925f.png)

after:
![after](https://user-images.githubusercontent.com/1804541/45972899-405a5500-c03d-11e8-962d-dd2a2fe36366.png)
