### PR TITLE
Youtube update: element selector fix

### DIFF
--- a/subs-ui.js
+++ b/subs-ui.js
@@ -249,7 +249,7 @@ function removeWatchedAndAddButton() {
                 markUnwatched(getVideoId(item)); //since its marked watched by YouTube, remove from storage to free space
             }
         } else {
-            let dismissableDiv = item.firstChild;
+            let dismissableDiv = item.firstElementChild;
 
             // does it already have the "Mark as Watched" button?
             if (dismissableDiv.querySelector("#" + MARK_WATCHED_BTN) != null) {


### PR DESCRIPTION
item.firstChild is now returning a comment after a YouTube code update
Changed the element selector to item.firstElementChild to select the dismissableDiv

![image](https://user-images.githubusercontent.com/37633200/77996642-daf6bc80-72e2-11ea-942a-406b700448a2.png)
![image](https://user-images.githubusercontent.com/37633200/77996734-04afe380-72e3-11ea-973f-ccc3195be687.png)

Thanks for this awesome extension, hope this saved you a bit of free time :)