### PR TITLE
Personal tweaks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: TheDoctor0/zip-release@v0.3.0
         with:
           filename: yt-better-subscriptions-latest.zip
-          exclusions: chrome_promo_tiles, .editorconfig, .gitignore
+          exclusions: '*.git* .editorconfig chrome_promo_tiles'
           
       - name: Get the version
         id: get_version

--- a/common.css
+++ b/common.css
@@ -3,3 +3,7 @@
 .hidden {
   display: none;
 }
+
+.semitransparent {
+  opacity: 0.5 !important;
+}

--- a/common.js
+++ b/common.js
@@ -3,6 +3,7 @@ const PREFIX = "osasoft-better-subscriptions_";
 const DEFAULT_SETTINGS = {
     "settings.hide.watched.label": true,
     "settings.hide.watched.default": true,
+    "settings.hide.watched.keep.state": true,
     "settings.hide.watched.refresh.rate": 3000,
     "settings.log.enabled": false,
     "settings.hide.watched.support.channel": true

--- a/common.js
+++ b/common.js
@@ -4,7 +4,8 @@ const DEFAULT_SETTINGS = {
     "settings.hide.watched.label": true,
     "settings.hide.watched.default": true,
     "settings.hide.watched.refresh.rate": 3000,
-    "settings.log.enabled": false
+    "settings.log.enabled": false,
+    "settings.hide.watched.support.channel": true
 };
 
 const SETTINGS_KEY = "settings";

--- a/common.js
+++ b/common.js
@@ -2,6 +2,7 @@ const PREFIX = "osasoft-better-subscriptions_";
 
 const DEFAULT_SETTINGS = {
     "settings.hide.watched.label": true,
+    "settings.hide.watched.all.label": true,
     "settings.hide.watched.default": true,
     "settings.hide.watched.keep.state": true,
     "settings.hide.watched.refresh.rate": 3000,

--- a/common.js
+++ b/common.js
@@ -6,7 +6,8 @@ const DEFAULT_SETTINGS = {
     "settings.hide.watched.keep.state": true,
     "settings.hide.watched.refresh.rate": 3000,
     "settings.log.enabled": false,
-    "settings.hide.watched.support.channel": true
+    "settings.hide.watched.support.channel": true,
+    "settings.hide.watched.auto.store": true
 };
 
 const SETTINGS_KEY = "settings";

--- a/common.js
+++ b/common.js
@@ -22,6 +22,14 @@ function getStorage() {
     return brwsr.storage.local; //TODO: use sync?
 }
 
+function loadStorage() {
+    return new Promise(function (resolve, reject) {
+        getStorage().get(null, function (items) {
+            resolve(items);
+        });
+    })
+}
+
 function getSyncStorage() {
     return brwsr.storage.sync;
 }

--- a/common.js
+++ b/common.js
@@ -3,6 +3,7 @@ const PREFIX = "osasoft-better-subscriptions_";
 const DEFAULT_SETTINGS = {
     "settings.hide.watched.label": true,
     "settings.hide.watched.all.label": true,
+    "settings.hide.watched.ui.stick.right": false,
     "settings.hide.watched.default": true,
     "settings.hide.watched.keep.state": true,
     "settings.hide.watched.refresh.rate": 3000,

--- a/images/markunwatched.svg
+++ b/images/markunwatched.svg
@@ -78,7 +78,7 @@
     r="2"
     id="circle3751"
     style="filter:url(#filter3775);fill:#ffffff"/>
-  <line x1="4" x2="22" y1="90%" y2="10%" stroke="white" stroke-width="3"/>
-  <line x1="22" x2="4" y1="90%" y2="10%" stroke="white" stroke-width="3"/>
+  <line x1="2" x2="22" y1="90%" y2="10%" stroke="white" stroke-width="3"/>
+  <line x1="22" x2="2" y1="90%" y2="10%" stroke="white" stroke-width="3"/>
   <text x="25" y="17" style="font: bold 12px sans-serif; fill: white;">WATCHED</text>
 </svg>

--- a/manifest.json
+++ b/manifest.json
@@ -49,6 +49,7 @@
     "scripts": ["pages/background.js"]
   },
   "options_ui": {
-    "page": "pages/settings/settings.html"
+    "page": "pages/settings/settings.html",
+    "open_in_tab": true
   }
 }

--- a/pageHandler.js
+++ b/pageHandler.js
@@ -8,7 +8,8 @@ function initExtension() {
 
     const PAGES = Object.freeze({
         "subscriptions": "/feed/subscriptions",
-        "video": "/watch"
+        "video": "/watch",
+        "channel": "/videos",
     });
 
     function handlePageChange(page) {
@@ -28,7 +29,10 @@ function initExtension() {
                     break;
                 case PAGES.video:
                     onVideoPage();
-                    break
+                    break;
+                default:
+                    if (page.includes(PAGES.channel) && settings["settings.hide.watched.support.channel"])
+                        initSubs();
             }
         } catch (e) {
             logError(e)

--- a/pages/settings/settings.css
+++ b/pages/settings/settings.css
@@ -1,0 +1,20 @@
+body {
+  margin: 0;
+  font-family: "Segoe UI", Tahoma, sans-serif;
+  font-size: 12px;
+}
+
+h4 {
+  padding: 10px;
+}
+
+.settings__container {
+  margin: 0 auto;
+  max-width: 800px;
+  padding: 0 10px;
+  background-color: #f4f6ff;
+}
+
+button#watched\.clear {
+  color: red !important;
+}

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -63,6 +63,9 @@
 
       <input id="settings.hide.watched.all.label" type="checkbox"/>
       <label for="settings.hide.watched.all.label">Show "Mark all as watched" label</label><br/>
+
+      <input id="settings.hide.watched.ui.stick.right" type="checkbox"/>
+      <label for="settings.hide.watched.ui.stick.right">Stick UI to the right menu</label><br/>
       <br/>
 
       <input id="settings.hide.watched.default" type="checkbox"/>

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -4,155 +4,165 @@
   <title>Settings for Better Subscriptions for YouTube&trade;</title>
 
   <link rel="stylesheet" type="text/css" href="../../common.css"/>
+  <link rel="stylesheet" type="text/css" href="settings.css"/>
 
   <script src="../../common.js"></script>
   <script src="../../settingsLoader.js"></script>
   <script src="../../util.js"></script>
   <script src="settings.js"></script>
 </head>
+<body>
+<div class="settings__container">
+  <h1>Settings for Better Subscriptions for YouTube&trade;</h1>
 
-<h1>Settings for Better Subscriptions for YouTube&trade;</h1>
+  <h2>Support pages</h2>
 
-<h2>Support pages</h2>
+  <div class="sk-circle">
+    <div class="sk-circle1 sk-child"></div>
+    <div class="sk-circle2 sk-child"></div>
+    <div class="sk-circle3 sk-child"></div>
+    <div class="sk-circle4 sk-child"></div>
+    <div class="sk-circle5 sk-child"></div>
+    <div class="sk-circle6 sk-child"></div>
+    <div class="sk-circle7 sk-child"></div>
+    <div class="sk-circle8 sk-child"></div>
+    <div class="sk-circle9 sk-child"></div>
+    <div class="sk-circle10 sk-child"></div>
+    <div class="sk-circle11 sk-child"></div>
+    <div class="sk-circle12 sk-child"></div>
+  </div>
 
-<div class="sk-circle">
-  <div class="sk-circle1 sk-child"></div>
-  <div class="sk-circle2 sk-child"></div>
-  <div class="sk-circle3 sk-child"></div>
-  <div class="sk-circle4 sk-child"></div>
-  <div class="sk-circle5 sk-child"></div>
-  <div class="sk-circle6 sk-child"></div>
-  <div class="sk-circle7 sk-child"></div>
-  <div class="sk-circle8 sk-child"></div>
-  <div class="sk-circle9 sk-child"></div>
-  <div class="sk-circle10 sk-child"></div>
-  <div class="sk-circle11 sk-child"></div>
-  <div class="sk-circle12 sk-child"></div>
-</div>
+  <div id="settings-support-pages" class="hidden">
+    <form>
+      <input id="settings.hide.watched.support.channel" type="checkbox"/>
+      <label for="settings.hide.watched.support.channel">Enable extension for channel videos page</label>
+    </form>
+  </div>
 
-<div id="settings-support-pages" class="hidden">
-  <form>
-    <label for="settings.hide.watched.support.channel">Enable extension for channel videos page</label>
-    <input id="settings.hide.watched.support.channel" type="checkbox"/><br/>
-  </form>
-</div>
+  <h2>Subscriptions Feed</h2>
 
-<h2>Subscriptions Feed</h2>
+  <div class="sk-circle">
+    <div class="sk-circle1 sk-child"></div>
+    <div class="sk-circle2 sk-child"></div>
+    <div class="sk-circle3 sk-child"></div>
+    <div class="sk-circle4 sk-child"></div>
+    <div class="sk-circle5 sk-child"></div>
+    <div class="sk-circle6 sk-child"></div>
+    <div class="sk-circle7 sk-child"></div>
+    <div class="sk-circle8 sk-child"></div>
+    <div class="sk-circle9 sk-child"></div>
+    <div class="sk-circle10 sk-child"></div>
+    <div class="sk-circle11 sk-child"></div>
+    <div class="sk-circle12 sk-child"></div>
+  </div>
 
-<div class="sk-circle">
-  <div class="sk-circle1 sk-child"></div>
-  <div class="sk-circle2 sk-child"></div>
-  <div class="sk-circle3 sk-child"></div>
-  <div class="sk-circle4 sk-child"></div>
-  <div class="sk-circle5 sk-child"></div>
-  <div class="sk-circle6 sk-child"></div>
-  <div class="sk-circle7 sk-child"></div>
-  <div class="sk-circle8 sk-child"></div>
-  <div class="sk-circle9 sk-child"></div>
-  <div class="sk-circle10 sk-child"></div>
-  <div class="sk-circle11 sk-child"></div>
-  <div class="sk-circle12 sk-child"></div>
-</div>
+  <div id="settings-subscriptions" class="hidden">
+    <form>
+      <input id="settings.hide.watched.label" type="checkbox"/>
+      <label for="settings.hide.watched.label">Show "Hide Watched" label</label><br/>
 
-<div id="settings-subscriptions" class="hidden">
-  <form>
-    <label for="settings.hide.watched.label">Show Hide Watched label</label>
-    <input id="settings.hide.watched.label" type="checkbox"/><br/>
+      <input id="settings.hide.watched.all.label" type="checkbox"/>
+      <label for="settings.hide.watched.all.label">Show "Mark all as watched" label</label><br/>
+      <br/>
 
-    <label for="settings.hide.watched.all.label">Show Mark All As Watched label</label>
-    <input id="settings.hide.watched.all.label" type="checkbox"/><br/>
+      <input id="settings.hide.watched.default" type="checkbox"/>
+      <label for="settings.hide.watched.default">Hide watched default state</label><br/>
 
-    <label for="settings.hide.watched.default">Hide watched default state</label>
-    <input id="settings.hide.watched.default" type="checkbox"/><br/>
+      <input id="settings.hide.watched.keep.state" type="checkbox"/>
+      <label for="settings.hide.watched.keep.state">Keep the state of "Hide Watched" checkbox (while you are not reloading
+        the page)</label><br/>
+      <br/>
 
-    <label for="settings.hide.watched.keep.state">Keep the state of Hide Watched checkbox (while you are not reloading the page)</label>
-    <input id="settings.hide.watched.keep.state" type="checkbox"/><br/>
+      <label for="settings.hide.watched.refresh.rate">Refresh rate for feed clearing (milliseconds)</label>
+      <input id="settings.hide.watched.refresh.rate" type="number"/><br/>
+      <label for="settings.hide.watched.refresh.rate">(currently works only in "hide watched" state)</label>
 
-    <label for="settings.hide.watched.refresh.rate">Refresh rate for feed clearing (milliseconds)</label>
-    <input id="settings.hide.watched.refresh.rate" type="number"/><br/>
-  </form>
+    </form>
+  </div>
+
+  <h2>General settings</h2>
+
+  <div class="sk-circle">
+    <div class="sk-circle1 sk-child"></div>
+    <div class="sk-circle2 sk-child"></div>
+    <div class="sk-circle3 sk-child"></div>
+    <div class="sk-circle4 sk-child"></div>
+    <div class="sk-circle5 sk-child"></div>
+    <div class="sk-circle6 sk-child"></div>
+    <div class="sk-circle7 sk-child"></div>
+    <div class="sk-circle8 sk-child"></div>
+    <div class="sk-circle9 sk-child"></div>
+    <div class="sk-circle10 sk-child"></div>
+    <div class="sk-circle11 sk-child"></div>
+    <div class="sk-circle12 sk-child"></div>
+  </div>
+
+  <div id="settings-general" class="hidden">
+    <form>
+      <input id="settings.hide.watched.auto.store" type="checkbox"/>
+      <label for="settings.hide.watched.auto.store">Set video as watched when you click on it.</label><br/>
+
+      <input id="settings.log.enabled" type="checkbox"/>
+      <label for="settings.log.enabled">Enable logging</label><br/>
+    </form>
+  </div>
+
+  <!--<h2>Other settings</h2>-->
+
+  <!--<div class="sk-circle">-->
+  <!--  <div class="sk-circle1 sk-child"></div>-->
+  <!--  <div class="sk-circle2 sk-child"></div>-->
+  <!--  <div class="sk-circle3 sk-child"></div>-->
+  <!--  <div class="sk-circle4 sk-child"></div>-->
+  <!--  <div class="sk-circle5 sk-child"></div>-->
+  <!--  <div class="sk-circle6 sk-child"></div>-->
+  <!--  <div class="sk-circle7 sk-child"></div>-->
+  <!--  <div class="sk-circle8 sk-child"></div>-->
+  <!--  <div class="sk-circle9 sk-child"></div>-->
+  <!--  <div class="sk-circle10 sk-child"></div>-->
+  <!--  <div class="sk-circle11 sk-child"></div>-->
+  <!--  <div class="sk-circle12 sk-child"></div>-->
+  <!--</div>-->
+
+  <!--<div id="settings-other" class="hidden">-->
+  <!--  More settings to come soon!-->
+  <!--</div>-->
+
+  <button id="settings-save">Save Settings</button>
+
+  <h2>Watched videos list actions</h2>
+
+  <div class="sk-circle">
+    <div class="sk-circle1 sk-child"></div>
+    <div class="sk-circle2 sk-child"></div>
+    <div class="sk-circle3 sk-child"></div>
+    <div class="sk-circle4 sk-child"></div>
+    <div class="sk-circle5 sk-child"></div>
+    <div class="sk-circle6 sk-child"></div>
+    <div class="sk-circle7 sk-child"></div>
+    <div class="sk-circle8 sk-child"></div>
+    <div class="sk-circle9 sk-child"></div>
+    <div class="sk-circle10 sk-child"></div>
+    <div class="sk-circle11 sk-child"></div>
+    <div class="sk-circle12 sk-child"></div>
+  </div>
+
+  <div id="settings-watched-manipulation" class="hidden">
+    <button id="watched.export">Export watched videos</button><br/>
+    <br/>
+    <button id="watched.import">Import watched videos</button>
+    <input id="watched.import.file" type="file"/><br/>
+    <br/>
+    <button id="watched.clear">Clear watched videos</button>
+  </div>
+
   <br/>
-  More settings to come soon!
-</div>
-
-<h2>General settings</h2>
-
-<div class="sk-circle">
-  <div class="sk-circle1 sk-child"></div>
-  <div class="sk-circle2 sk-child"></div>
-  <div class="sk-circle3 sk-child"></div>
-  <div class="sk-circle4 sk-child"></div>
-  <div class="sk-circle5 sk-child"></div>
-  <div class="sk-circle6 sk-child"></div>
-  <div class="sk-circle7 sk-child"></div>
-  <div class="sk-circle8 sk-child"></div>
-  <div class="sk-circle9 sk-child"></div>
-  <div class="sk-circle10 sk-child"></div>
-  <div class="sk-circle11 sk-child"></div>
-  <div class="sk-circle12 sk-child"></div>
-</div>
-
-<div id="settings-general" class="hidden">
-  <form>
-    <label for="settings.hide.watched.auto.store">Set video as watched when you click on it.</label>
-    <input id="settings.hide.watched.auto.store" type="checkbox"/><br/>
-
-    <label for="settings.log.enabled">Enable logging</label>
-    <input id="settings.log.enabled" type="checkbox"/><br/>
-  </form>
-</div>
-
-<!--<h2>Other settings</h2>-->
-
-<!--<div class="sk-circle">-->
-<!--  <div class="sk-circle1 sk-child"></div>-->
-<!--  <div class="sk-circle2 sk-child"></div>-->
-<!--  <div class="sk-circle3 sk-child"></div>-->
-<!--  <div class="sk-circle4 sk-child"></div>-->
-<!--  <div class="sk-circle5 sk-child"></div>-->
-<!--  <div class="sk-circle6 sk-child"></div>-->
-<!--  <div class="sk-circle7 sk-child"></div>-->
-<!--  <div class="sk-circle8 sk-child"></div>-->
-<!--  <div class="sk-circle9 sk-child"></div>-->
-<!--  <div class="sk-circle10 sk-child"></div>-->
-<!--  <div class="sk-circle11 sk-child"></div>-->
-<!--  <div class="sk-circle12 sk-child"></div>-->
-<!--</div>-->
-
-<!--<div id="settings-other" class="hidden">-->
-<!--  More settings to come soon!-->
-<!--</div>-->
-
-<button id="settings-save">Save Settings</button>
-
-<h2>Watched videos list actions</h2>
-
-<div class="sk-circle">
-  <div class="sk-circle1 sk-child"></div>
-  <div class="sk-circle2 sk-child"></div>
-  <div class="sk-circle3 sk-child"></div>
-  <div class="sk-circle4 sk-child"></div>
-  <div class="sk-circle5 sk-child"></div>
-  <div class="sk-circle6 sk-child"></div>
-  <div class="sk-circle7 sk-child"></div>
-  <div class="sk-circle8 sk-child"></div>
-  <div class="sk-circle9 sk-child"></div>
-  <div class="sk-circle10 sk-child"></div>
-  <div class="sk-circle11 sk-child"></div>
-  <div class="sk-circle12 sk-child"></div>
-</div>
-
-<div id="settings-watched-manipulation" class="hidden">
-  <button id="watched.export">Export watched videos</button><br/>
-  <button id="watched.import">Import watched videos</button>
-  <input id="watched.import.file" type="file"/><br/>
   <br/>
-  <button id="watched.clear">Clear watched videos</button>
+  <br/>
+  <br/>
+  <br/>
+  <h4>Have a suggestion what else could go into the settings page or overall improve the addon? Something doesn't work
+    as it should? Please feel free to raise an issue on <a
+      href="https://github.com/OsaSoft/youtube-better-subscriptions/issues">GitHub</a></h4>
 </div>
-
-<br/>
-<br/>
-<br/>
-<br/>
-<br/>
-<h4>Have a suggestion what else could go into the settings page or overall improve the addon? Something doesn't work as it should? Please feel free to raise an issue on <a href="https://github.com/OsaSoft/youtube-better-subscriptions/issues">GitHub</a></h4>
+</body>

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -59,6 +59,9 @@
     <label for="settings.hide.watched.label">Show Hide Watched label</label>
     <input id="settings.hide.watched.label" type="checkbox"/><br/>
 
+    <label for="settings.hide.watched.all.label">Show Mark All As Watched label</label>
+    <input id="settings.hide.watched.all.label" type="checkbox"/><br/>
+
     <label for="settings.hide.watched.default">Hide watched default state</label>
     <input id="settings.hide.watched.default" type="checkbox"/><br/>
 

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -15,30 +15,6 @@
 <div class="settings__container">
   <h1>Settings for Better Subscriptions for YouTube&trade;</h1>
 
-  <h2>Support pages</h2>
-
-  <div class="sk-circle">
-    <div class="sk-circle1 sk-child"></div>
-    <div class="sk-circle2 sk-child"></div>
-    <div class="sk-circle3 sk-child"></div>
-    <div class="sk-circle4 sk-child"></div>
-    <div class="sk-circle5 sk-child"></div>
-    <div class="sk-circle6 sk-child"></div>
-    <div class="sk-circle7 sk-child"></div>
-    <div class="sk-circle8 sk-child"></div>
-    <div class="sk-circle9 sk-child"></div>
-    <div class="sk-circle10 sk-child"></div>
-    <div class="sk-circle11 sk-child"></div>
-    <div class="sk-circle12 sk-child"></div>
-  </div>
-
-  <div id="settings-support-pages" class="hidden">
-    <form>
-      <input id="settings.hide.watched.support.channel" type="checkbox"/>
-      <label for="settings.hide.watched.support.channel">Enable extension for channel videos page</label>
-    </form>
-  </div>
-
   <h2>Subscriptions Feed</h2>
 
   <div class="sk-circle">
@@ -72,14 +48,41 @@
       <label for="settings.hide.watched.default">Hide watched default state</label><br/>
 
       <input id="settings.hide.watched.keep.state" type="checkbox"/>
-      <label for="settings.hide.watched.keep.state">Keep the state of "Hide Watched" checkbox (while you are not reloading
-        the page)</label><br/>
+      <label for="settings.hide.watched.keep.state">
+        Keep the state of "Hide Watched" checkbox through navigation
+        (allows you to go on video/channel/sub/etc pages and save the state of "Hide Watched" checkbox despite the
+        default value (it will be applied on reload).)
+      </label><br/>
       <br/>
 
       <label for="settings.hide.watched.refresh.rate">Refresh rate for feed clearing (milliseconds)</label>
       <input id="settings.hide.watched.refresh.rate" type="number"/><br/>
       <label for="settings.hide.watched.refresh.rate">(currently works only in "hide watched" state)</label>
 
+    </form>
+  </div>
+
+  <h2>Other YouTube&trade; pages</h2>
+
+  <div class="sk-circle">
+    <div class="sk-circle1 sk-child"></div>
+    <div class="sk-circle2 sk-child"></div>
+    <div class="sk-circle3 sk-child"></div>
+    <div class="sk-circle4 sk-child"></div>
+    <div class="sk-circle5 sk-child"></div>
+    <div class="sk-circle6 sk-child"></div>
+    <div class="sk-circle7 sk-child"></div>
+    <div class="sk-circle8 sk-child"></div>
+    <div class="sk-circle9 sk-child"></div>
+    <div class="sk-circle10 sk-child"></div>
+    <div class="sk-circle11 sk-child"></div>
+    <div class="sk-circle12 sk-child"></div>
+  </div>
+
+  <div id="settings-support-pages" class="hidden">
+    <form>
+      <input id="settings.hide.watched.support.channel" type="checkbox"/>
+      <label for="settings.hide.watched.support.channel">Enable extension for channel videos page</label>
     </form>
   </div>
 
@@ -103,7 +106,10 @@
   <div id="settings-general" class="hidden">
     <form>
       <input id="settings.hide.watched.auto.store" type="checkbox"/>
-      <label for="settings.hide.watched.auto.store">Set video as watched when you click on it.</label><br/>
+      <label for="settings.hide.watched.auto.store">
+        Set video as watched when you click on it.
+        (Disabling this means videos are only marked as watched when you click the 'Mark as watched' icon)
+      </label><br/>
 
       <input id="settings.log.enabled" type="checkbox"/>
       <label for="settings.log.enabled">Enable logging</label><br/>
@@ -151,7 +157,8 @@
   </div>
 
   <div id="settings-watched-manipulation" class="hidden">
-    <button id="watched.export">Export watched videos</button><br/>
+    <button id="watched.export">Export watched videos</button>
+    <br/>
     <br/>
     <button id="watched.import">Import watched videos</button>
     <input id="watched.import.file" type="file"/><br/>

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -13,6 +13,30 @@
 
 <h1>Settings for Better Subscriptions for YouTube&trade;</h1>
 
+<h2>Support pages</h2>
+
+<div class="sk-circle">
+  <div class="sk-circle1 sk-child"></div>
+  <div class="sk-circle2 sk-child"></div>
+  <div class="sk-circle3 sk-child"></div>
+  <div class="sk-circle4 sk-child"></div>
+  <div class="sk-circle5 sk-child"></div>
+  <div class="sk-circle6 sk-child"></div>
+  <div class="sk-circle7 sk-child"></div>
+  <div class="sk-circle8 sk-child"></div>
+  <div class="sk-circle9 sk-child"></div>
+  <div class="sk-circle10 sk-child"></div>
+  <div class="sk-circle11 sk-child"></div>
+  <div class="sk-circle12 sk-child"></div>
+</div>
+
+<div id="settings-support-pages" class="hidden">
+  <form>
+    <label for="settings.hide.watched.support.channel">Enable extension for channel videos page</label>
+    <input id="settings.hide.watched.support.channel" type="checkbox"/><br/>
+  </form>
+</div>
+
 <h2>Subscriptions Feed</h2>
 
 <div class="sk-circle">

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -91,6 +91,9 @@
 
 <div id="settings-general" class="hidden">
   <form>
+    <label for="settings.hide.watched.auto.store">Set video as watched when you click on it.</label>
+    <input id="settings.hide.watched.auto.store" type="checkbox"/><br/>
+
     <label for="settings.log.enabled">Enable logging</label>
     <input id="settings.log.enabled" type="checkbox"/><br/>
   </form>

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -62,6 +62,9 @@
     <label for="settings.hide.watched.default">Hide watched default state</label>
     <input id="settings.hide.watched.default" type="checkbox"/><br/>
 
+    <label for="settings.hide.watched.keep.state">Keep the state of Hide Watched checkbox (while you are not reloading the page)</label>
+    <input id="settings.hide.watched.keep.state" type="checkbox"/><br/>
+
     <label for="settings.hide.watched.refresh.rate">Refresh rate for feed clearing (milliseconds)</label>
     <input id="settings.hide.watched.refresh.rate" type="number"/><br/>
   </form>

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -79,16 +79,18 @@ function addSettingsButton() {
 }
 
 function addHideAllMenuButton() {
-    let hideAllButtonContainer = buildMenuButtonContainer();
-    hideAllButtonContainer.classList.add("subs-grid-menu-mark-all");
-    hideAllButtonContainer.setAttribute("id", MARK_ALL_WATCHED_BTN);
+    if (settings["settings.hide.watched.all.label"]) {
+        let hideAllButtonContainer = buildMenuButtonContainer();
+        hideAllButtonContainer.classList.add("subs-grid-menu-mark-all");
+        hideAllButtonContainer.setAttribute("id", MARK_ALL_WATCHED_BTN);
 
-    hideAllButtonContainer.appendChild(document.createTextNode("Mark all as watched"));
+        hideAllButtonContainer.appendChild(document.createTextNode("Mark all as watched"));
 
-    addElementToMenuUI(hideAllButtonContainer);
+        addElementToMenuUI(hideAllButtonContainer);
 
-    let messenger = document.getElementById(MARK_ALL_WATCHED_BTN);
-    messenger.addEventListener("click", markAllAsWatched);
+        let messenger = document.getElementById(MARK_ALL_WATCHED_BTN);
+        messenger.addEventListener("click", markAllAsWatched);
+    }
 }
 
 function addHideWatchedCheckbox() {

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -25,7 +25,7 @@ function changeMarkWatchedToMarkUnwatched(item) {
         let dismissibleDiv = metaDataLine.parentNode;
         dismissibleDiv.removeChild(metaDataLine);
 
-        let markUnwatchedBtn = buildMarkWatchedButton(item, getVideoId(item), false);
+        let markUnwatchedBtn = buildMarkWatchedButton(dismissibleDiv, item, getVideoId(item), false);
         dismissibleDiv.appendChild(markUnwatchedBtn);
     }
 }
@@ -144,7 +144,7 @@ function addElementToMenuUI(element) {
     addedElems.push(element);
 }
 
-function buildMarkWatchedButton(item, videoId, isMarkWatchedBtn = true) {
+function buildMarkWatchedButton(dismissibleDiv, item, videoId, isMarkWatchedBtn = true) {
     let enclosingDiv = document.createElement("div");
     enclosingDiv.setAttribute("id", METADATA_LINE);
     enclosingDiv.classList.add("style-scope", "ytd-thumbnail-overlay-toggle-button-renderer");
@@ -163,11 +163,16 @@ function buildMarkWatchedButton(item, videoId, isMarkWatchedBtn = true) {
             let metaDataElem = item.querySelector("#" + METADATA_LINE);
             let container = metaDataElem.parentNode;
             container.removeChild(metaDataElem);
-            container.appendChild(buildMarkWatchedButton(item, videoId));
+            container.appendChild(buildMarkWatchedButton(dismissibleDiv, item, videoId));
         }
     }
 
     enclosingDiv.appendChild(button);
+
+    if (isMarkWatchedBtn)
+        dismissibleDiv.classList.remove("semitransparent");
+    else
+        dismissibleDiv.classList.add("semitransparent");
 
     return enclosingDiv;
 }
@@ -262,9 +267,8 @@ function removeWatchedAndAddButton() {
                 }
             }
 
-            let markAsWatchedButton = buildMarkWatchedButton(item, getVideoId(item));
-            dismissableDiv.appendChild(markAsWatchedButton);
-        }
+        let markAsWatchedButton = buildMarkWatchedButton(dismissableDiv, item, getVideoId(item));
+        dismissableDiv.appendChild(markAsWatchedButton);
     }
     log("Removing watched from feed and adding overlay... Done");
 

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -34,7 +34,6 @@ function showWatched() {
     log("Showing watched videos");
 
     for (let item of hidden) {
-        changeMarkWatchedToMarkUnwatched(item);
         item.style.display = '';
         item.classList.remove(HIDDEN_CLASS);
     }
@@ -244,31 +243,29 @@ function removeWatchedAndAddButton() {
 
     for (let item of els) {
         let stored = getVideoId(item) in storage;
-        let ytWatched = isYouTubeWatched(item);
+        let dismissableDiv = item.firstElementChild;
+        let button = stored? MARK_UNWATCHED_BTN : MARK_WATCHED_BTN;
 
-        if (stored || ytWatched) {
+        if (stored && hideWatched) {
             hideItem(item);
             hiddenCount++;
+        }
 
-            if (stored && ytWatched) {
-                markUnwatched(getVideoId(item)); //since its marked watched by YouTube, remove from storage to free space
-            }
+        // does it already have any button?
+        if (dismissableDiv.querySelector("#" + button) != null) {
+            continue;
         } else {
-            let dismissableDiv = item.firstElementChild;
+            dismissableDiv = dismissableDiv.firstChild;
 
-            // does it already have the "Mark as Watched" button?
-            if (dismissableDiv.querySelector("#" + MARK_WATCHED_BTN) != null) {
-                continue;
-            } else {
+            if (!isPolymer) {
                 dismissableDiv = dismissableDiv.firstChild;
-
-                if (!isPolymer) {
-                    dismissableDiv = dismissableDiv.firstChild;
-                }
             }
+        }
 
-        let markAsWatchedButton = buildMarkWatchedButton(dismissableDiv, item, getVideoId(item));
-        dismissableDiv.appendChild(markAsWatchedButton);
+        // stored = false - build "Mark as watched"
+        // stored = true  - build "Mark as unwatched"
+        let markButton = buildMarkWatchedButton(dismissableDiv, item, getVideoId(item), !stored);
+        dismissableDiv.appendChild(markButton);
     }
     log("Removing watched from feed and adding overlay... Done");
 

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -48,6 +48,9 @@ function buildUI() {
     addHideWatchedCheckbox();
     addHideAllMenuButton();
     addSettingsButton();
+
+    if (settings["settings.hide.watched.ui.stick.right"])
+        addedElems[0].after(...addedElems)
 }
 
 function buildMenuButtonContainer() {
@@ -133,7 +136,10 @@ function addElementToMenuUI(element) {
     if (isPolymer) { //is new layout?
         let topMenuEnd = document.getElementById("end");
         if (topMenuEnd != null) { //just in case...
-            topMenuEnd.parentNode.insertBefore(element, topMenuEnd);
+            if (settings["settings.hide.watched.ui.stick.right"])
+                topMenuEnd.prepend(element);
+            else
+                topMenuEnd.parentNode.insertBefore(element, topMenuEnd);
         }
     } else {
         let uiContainer = document.getElementById("yt-masthead-user");

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -209,6 +209,8 @@ function processSections() {
 
     for (let section of sections) {
         let sectionHeader = section.querySelector(sectionTitleQuery());
+        // Temporary fix for PAGES.channel TODO: refactor this (when more pages added)
+        if (!sectionHeader) break;
         let sectionTitle = sectionHeader.textContent;
 
         // add collapse button to sections
@@ -282,4 +284,14 @@ function removeUI() {
     });
 
     addedElems = [];
+
+    // delete built buttons
+    document.querySelectorAll("#" + METADATA_LINE).forEach(e => e.remove());
+
+    // make hidden videos visible
+    for (let item of hidden) {
+        item.style.display = '';
+        item.classList.remove(HIDDEN_CLASS);
+    }
+    hidden = [];
 }

--- a/subs.css
+++ b/subs.css
@@ -1,10 +1,12 @@
 .subs-btn-settings {
   height: 24px;
+  padding: 0 10pt !important;
   background-image: url('images/icon_settings.svg'), /*works in Firefox*/ url('chrome-extension://__MSG_@@extension_id__/images/icon_settings.svg'); /*works in Chrome*/
 }
 
 .subs-btn-hide-watched-checked, .subs-btn-hide-watched-unchecked {
   opacity: .8;
+  margin: 0 12px !important;
 }
 
 .subs-btn-hide-watched-checked .toggle-button {
@@ -61,8 +63,7 @@ ytd-grid-video-renderer.style-scope.ytd-grid-renderer:hover .subs-btn-mark-watch
 }
 
 .subs-grid-menu-item {
-  padding-left: 10pt !important;
-  padding-right: 10pt !important;
+  margin: 0 12px !important;
 }
 
 .subs-grid-menu-mark-all {
@@ -81,4 +82,8 @@ ytd-grid-video-renderer.style-scope.ytd-grid-renderer:hover .subs-btn-mark-watch
 
 #osasoft-better-subscriptions_subs-grid {
   vertical-align: -3px;
+}
+
+#end.ytd-masthead {
+  min-width: auto !important;
 }

--- a/subs.css
+++ b/subs.css
@@ -34,6 +34,7 @@
 }
 
 .subs-btn-mark-watched {
+  display: none;
   width: 24px;
   background-image: url('images/markwatched.svg'), /*works in Firefox*/ url('chrome-extension://__MSG_@@extension_id__/images/markwatched.svg'); /*works in Chrome*/
   background-size: cover;
@@ -53,6 +54,10 @@
 .subs-btn-mark-watched:active, .subs-btn-mark-unwatched:active, .subs-btn-hide-watched-checked:active, .subs-btn-hide-watched-unchecked:active {
   opacity: 1.0;
   cursor: pointer;
+}
+
+ytd-grid-video-renderer.style-scope.ytd-grid-renderer:hover .subs-btn-mark-watched {
+  display: inline-block;
 }
 
 .subs-grid-menu-item {

--- a/subs.css
+++ b/subs.css
@@ -2,6 +2,7 @@
   height: 24px;
   padding: 0 10pt !important;
   background-image: url('images/icon_settings.svg'), /*works in Firefox*/ url('chrome-extension://__MSG_@@extension_id__/images/icon_settings.svg'); /*works in Chrome*/
+  background-repeat: no-repeat;
 }
 
 .subs-btn-hide-watched-checked, .subs-btn-hide-watched-unchecked {

--- a/subs.js
+++ b/subs.js
@@ -3,17 +3,6 @@ let hidden = [];
 let hideWatched = null;
 let intervalId = null;
 
-function isYouTubeWatched(item) {
-    return (
-            (!isPolymer &&
-                    (item.getElementsByClassName("watched").length > 0 ||
-                            item.getElementsByClassName("contains-percent-duration-watched").length > 0)) || //has "WATCHED" on thumbnail
-            (isPolymer &&
-                    (item.querySelectorAll("yt-formatted-string.style-scope.ytd-thumbnail-overlay-playback-status-renderer").length > 0 || //has "WATCHED" on thumbnail
-                            item.querySelectorAll("#progress.style-scope.ytd-thumbnail-overlay-resume-playback-renderer").length > 0) || //has progress bar on thumbnail
-                    item.hasAttribute("is-dismissed")) //also hide empty blocks left in by pressing "HIDE" button
-    )
-}
 
 function markWatched(item, videoId) {
     changeMarkWatchedToMarkUnwatched(item);
@@ -117,28 +106,28 @@ function storageChangeCallback(changes, area) {
 function initSubs() {
     log("Initializing subs page...");
 
-    hideWatched = settings["settings.hide.watched.default"];
-
-    getStorage().get(null, items => { //fill our map with watched videos
+    loadStorage().then(function (items) {
         storage = items;
-    });
 
-    buildUI();
+        hideWatched = settings["settings.hide.watched.default"];
 
-    brwsr.storage.onChanged.addListener(storageChangeCallback);
+        buildUI();
 
-    intervalId = window.setInterval(function () {
-        if (hideWatched) {
-            try {
-                removeWatchedAndAddButton();
-            } catch (e) {
-                logError(e);
+        brwsr.storage.onChanged.addListener(storageChangeCallback);
+
+        intervalId = window.setInterval(function () {
+            if (hideWatched) {
+                try {
+                    removeWatchedAndAddButton();
+                } catch (e) {
+                    logError(e);
+                }
             }
-        }
-    }, settings["settings.hide.watched.refresh.rate"]);
+        }, settings["settings.hide.watched.refresh.rate"]);
 
-    removeWatchedAndAddButton();
+        removeWatchedAndAddButton();
 
+    });
     log("Initializing subs page... DONE");
 }
 

--- a/subs.js
+++ b/subs.js
@@ -109,7 +109,9 @@ function initSubs() {
     loadStorage().then(function (items) {
         storage = items;
 
-        hideWatched = settings["settings.hide.watched.default"];
+        if (hideWatched == null || !settings["settings.hide.watched.keep.state"]) {
+            hideWatched = settings["settings.hide.watched.default"];
+        }
 
         buildUI();
 

--- a/vid.js
+++ b/vid.js
@@ -1,6 +1,8 @@
 function onVideoPage() {
-    let videoId = new URL(window.location.href).searchParams.get("v");
+    if (settings["settings.hide.watched.auto.store"]) {
+        let videoId = new URL(window.location.href).searchParams.get("v");
 
-    log("Marking video " + videoId + " as watched from video page");
-    setVideoInStorage(videoId);
+        log("Marking video " + videoId + " as watched from video page");
+        setVideoInStorage(videoId);
+    }
 }


### PR DESCRIPTION
Greetings. Thanks for this extension, I like it a lot, so decided to contribute a bit (thanks for open source tho). Made this pull request to show the differences and I want to know your opinion about the changes (most of them are personal preferences I guess, but anyway).

Open for discussion, can refactor some stuff you don't probably like. Feel free to close this pull request if you want.

Would be glad to hear code style tips, if there any.

---

<details>
  <summary>You can expand me to see :framed_picture:</summary>
  down below
</details>

---

## Bugs fixed:

- <details>
    <summary>History for the first loaded videos was incorrect: UI was rendered before we get history from storage (so you won't see any "watched" videos at the beginning) jefuwork@f5048e5bd31fc761b5ba82a92aa83b967ce0514c </summary>

  ```
  old
  ```

  ![](https://i.imgur.com/57uLW7d.gif)

  ```
  new
  ```

  ![](https://i.imgur.com/eB2GWcP.gif)
  </details>

  Reason - loading from storage is an async function, so I wrapped it under a Promise object.

- <details>
    <summary>Videos loaded after you scroll down won't be marked as "watched" jefuwork@f5048e5bd31fc761b5ba82a92aa83b967ce0514c </summary>
  
  ```
  old
  ```

  ![](https://i.imgur.com/PPQF2hJ.gif)

  ```
  new
  ```

  ![](https://i.imgur.com/5eh4HZ9.gif)
  </details>

  Long story short (if I remember it correctly) the reason for this is that it's trying to change "not watched" button to "watched" one (when you load new videos in "hide watched" mode and then switch the toggle to "show watched" mode) - but "watched" videos weren't given any buttons on initialization.

  _Rebuild logic a bit for it to build UI only when history storage was loaded and create all buttons at the beginning._

  _**Resolves**_: https://github.com/OsaSoft/youtube-better-subscriptions/issues/65

### Minor fixes:

- <details>
    <summary>Fixed .subs-btn-settings SVG repeat (it appears when you hide any label or resize the window) jefuwork@48a569bd36a10fbdcce2b1056cce2cdbffba5579</summary>

  ![](https://i.imgur.com/YZ98fTM.png)
  ![](https://i.imgur.com/SgpCsJ2.png)
  </details>

- <details>
    <summary>SVG icon fix jefuwork@408c9a7e16f3beeff16fd644a6a0bf43d89dbf58</summary>

  ```
  old
  ```

  ![](https://i.imgur.com/rSwvtbf.png)

  ```
  new
  ```

  ![](https://i.imgur.com/QujXike.png)
  </details>

- <details>
    <summary>Open settings on a new page so you can see confirm dialog for storage clearing. (problem in Chrome). jefuwork@6f9ea46dfe4e52c314bc84f72c43af75959d768d</summary>
  
  ![](https://i.imgur.com/I6LIL6O.gif)
  </details>

  _Personally, I would add this in chrome version and ignore it in firefox._

## What's new:

- <details>
    <summary>Added support for channel videos page, added settings option to enable / disable it jefuwork@7ab3a29e14201d063e6d6bfab24058f6d40efa54</summary>
  
  ![](https://i.imgur.com/eEUbhQG.png)
  </details>

  _**Resolves**_: https://github.com/OsaSoft/youtube-better-subscriptions/issues/59

- Made watched videos semitransparent and show "Mark as Watched" button on video hover only jefuwork@ec7378c1b93851115946bcd4719d31819e05abf7 jefuwork@681f4d37a3eab50517ad2e9db2adff72757ef5b5
  _for better visual clarity_
- Deleted hiding videos marked as watched by YouTube, cause I find it kind of unreliable jefuwork@f5048e5bd31fc761b5ba82a92aa83b967ce0514c
  _(will add in future if needed)._

### Settings:

- Enable / disable support for channel videos page (channel/\*/vids page). 
- Added option to keep the state of "Hide Watched" checkbox (while you are not reloading the page). jefuwork@ea4cf3acb24577b88b0c4bc437569ea184bb23ac
  _It allows you to go on video / channel / sub / etc pages and save the state of "Hide Watched" checkbox despite the default value (it will be applied on reload)._

- Added option to set video watched when you click on it. jefuwork@6bead761892b0c3b82a3693ef73aa9803c931e07
- Added option to show / hide Mark all as watched label. jefuwork@b02f4967823dd96a9d906153e7601d62b68dde74
- <details>
    <summary>Added option to stick UI to the right menu. jefuwork@e9dad1ac1c0b2d25da8239d42554438b73f932ee</summary>
  
  ![](https://i.imgur.com/98JibHa.png)
  </details>

  _If you like minimalism or want to make ui more compact._

- <details>
    <summary>Minor page UI improvements. jefuwork@9ac73911decf3cd0d12067cf729ba2b4eeef96db</summary>
  
  ![](https://i.imgur.com/h1V4UNX.png)
  </details>

###### Need to mention that:

- Old layout wasn't tested
- Currently new buttons will be created in "Hide watched" mode
  _Like it was before_
