### PR TITLE
Adding feature: Hide watched videos on Youtube homepage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: TheDoctor0/zip-release@v0.3.0
         with:
           filename: yt-better-subscriptions-latest.zip
-          exclusions: chrome_promo_tiles, .editorconfig, .gitignore
+          exclusions: '*.git* .editorconfig chrome_promo_tiles'
           
       - name: Get the version
         id: get_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,12 @@ jobs:
       - name: Pack extension ZIP
         uses: TheDoctor0/zip-release@v0.3.0
         with:
-          filename: yt-better-subscriptions-${{ github.ref }}.zip
+          filename: yt-better-subscriptions-latest.zip
           exclusions: chrome_promo_tiles, .editorconfig, .gitignore
+          
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
 
       - name: Create Release
         id: create_release
@@ -27,7 +31,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          release_name: Release ${{ steps.get_version.outputs.VERSION }}
           draft: false
           prerelease: false
 
@@ -38,6 +42,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./yt-better-subscriptions-${{ github.ref }}.zip
-          asset_name: yt-better-subscriptions-${{ github.ref }}.zip
+          asset_path: ./yt-better-subscriptions-latest.zip
+          asset_name: yt-better-subscriptions-${{ steps.get_version.outputs.VERSION }}.zip
           asset_content_type: application/zip

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "Better Subs",
   "manifest_version": 2,
   "name": "Better Subscriptions for YouTube™",
-  "version": "0.13.1.1",
+  "version": "0.14",
   "applications": {
     "gecko": {
       "id": "{5dc6dafa-584e-424a-bf90-1d1d8cfa3caa}"

--- a/pageHandler.js
+++ b/pageHandler.js
@@ -8,7 +8,8 @@ function initExtension() {
 
     const PAGES = Object.freeze({
         "subscriptions": "/feed/subscriptions",
-        "video": "/watch"
+        "video": "/watch",
+		"home": ""
     });
 
     function handlePageChange(page) {
@@ -28,6 +29,9 @@ function initExtension() {
                     break;
                 case PAGES.video:
                     onVideoPage();
+                    break
+				case PAGES.home:
+                    initSubs();
                     break
             }
         } catch (e) {

--- a/pages/changelog.html
+++ b/pages/changelog.html
@@ -21,10 +21,9 @@
   The purpose of this page is to let you know what's changed or new in the extension and it will show up after
   installing or updating the extension to a new version.
 </p>
-
-<h2>What's new in version 0.13.1?</h2>
+<h2>What's new in version 0.14?</h2>
 <ul>
-  <li>This version fixes YouTube's slight change to their DOM layout in a recent update, which caused the extension to stop working.</li>
+  <li>This version adds support for the extension to hide watched videos on the YouTube homepage.</li>
 </ul>
 
 <h2>Want to help?</h2>
@@ -41,6 +40,9 @@
 
 <h2>Complete changelog</h2>
 <dl>
+  <dt>v0.13.1</dt>
+  <dd>This version fixes YouTube's slight change to their DOM layout in a recent update, which caused the extension to stop working.</dd>
+
   <dt>v0.13</dt>
   <dd>Added basic functionality to the settings page. Now supports saving and loading of configuration.</dd>
   <dd>Added basic configuration for subs feed to settings page.</dd>

--- a/queries.js
+++ b/queries.js
@@ -1,6 +1,6 @@
 function vidQuery() {
     if (isPolymer) {
-        return "ytd-grid-video-renderer.style-scope.ytd-grid-renderer:not(." + HIDDEN_CLASS + ")";
+        return "ytd-grid-video-renderer.style-scope.ytd-grid-renderer:not(." + HIDDEN_CLASS + ")" + ", ytd-rich-item-renderer.style-scope.ytd-rich-grid-renderer:not(." + HIDDEN_CLASS + ")";
     } else {
         return ".feed-item-container .yt-shelf-grid-item:not(." + HIDDEN_CLASS + ")";
     }

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -249,7 +249,7 @@ function removeWatchedAndAddButton() {
                 markUnwatched(getVideoId(item)); //since its marked watched by YouTube, remove from storage to free space
             }
         } else {
-            let dismissableDiv = item.firstElementChild;
+            let dismissableDiv = item.querySelector("#dismissable");
 
             // does it already have the "Mark as Watched" button?
             if (dismissableDiv.querySelector("#" + MARK_WATCHED_BTN) != null) {


### PR DESCRIPTION
Just as this extension hides watched videos on subscription page. With a bit of modification in files, the same feature is extended to homepage of Youtube as well. The UI buttons appear on homepage to enable/disable "hide watched videos" and the other button which makes all the videos on the webpage "watched". And the small icon on individual videos as well, where when you click, that video gets added to "watched" list.