### PR TITLE
#143 Fix null video href's break the Hide functionality on home screen

### DIFF
--- a/videos/Video.js
+++ b/videos/Video.js
@@ -7,7 +7,12 @@ function getVideoIdFromUrl(url) {
 }
 
 function getVideoId(item) {
-    return getVideoIdFromUrl(item.querySelectorAll("a")[0].getAttribute("href"));
+    let videoUrl = item.querySelectorAll("a")[0].getAttribute("href");
+    if (videoUrl != null) {
+        return getVideoIdFromUrl(videoUrl);
+    } else {
+        log("Video URL is null - ad.");
+    }
 }
 
 function changeMarkWatchedToMarkUnwatched(item) {
@@ -38,7 +43,12 @@ class Video {
         }
 
         log("Checking video " + this.videoId + " for short");
-        this.isShort = containingDiv.querySelectorAll("a")[0].getAttribute("href").includes("shorts");
+        let videoHref = containingDiv.querySelectorAll("a")[0].getAttribute("href");
+        if (videoHref != null) {
+            this.isShort = videoHref.includes("shorts");
+        } else {
+            log("Video URL is null - ad.");
+        }
     }
 
     hasButton() {


### PR DESCRIPTION
Stop evaluating if video href is null (only seen in inline ads so far?)

only minimally tested, on firefox.