### PR TITLE
Sync watch history

### DIFF
--- a/common.js
+++ b/common.js
@@ -17,6 +17,10 @@ const DEFAULT_SETTINGS = {
 };
 
 const SETTINGS_KEY = "settings";
+const VIDEO_WATCH_KEY = "vw_";
+
+// Storage sync set operations may be throttled https://developer.chrome.com/docs/extensions/reference/storage/#property-sync
+const WATCHED_SYNC_THROTTLE = 1000;
 
 let brwsr;
 try {
@@ -27,27 +31,98 @@ try {
     }
 }
 
-function getStorage() {
-    return brwsr.storage.local; //TODO: use sync?
+const watchedVideos = [];
+
+async function loadWatchedVideos() {
+    const items = await brwsr.storage.sync.get(null);
+    const batches = [];
+
+    for (const key in items) {
+        if (key.indexOf(VIDEO_WATCH_KEY) !== 0) {
+            continue;
+        }
+        const index = parseInt(key.slice(VIDEO_WATCH_KEY.length));
+
+        const watchedBatch = items[key];
+        if (!Array.isArray(watchedBatch)) {
+            console.error('Invalid watch history item', key);
+        }
+        batches[index] = watchedBatch;
+    }
+
+    watchedVideos.splice(0, watchedVideos.length);
+    for (const batch of batches) {
+        watchedVideos.push(...batch);
+    }
+
+    const oldItems = await brwsr.storage.local.get(null);
+    const sortedKeys = (
+        Object.keys(oldItems)
+            .filter(key => typeof oldItems[key] === 'number')
+            .sort((key1, key2) => oldItems[key2] - oldItems[key1])
+    );
+    if (sortedKeys.length) {
+        watchedVideos.unshift(...sortedKeys);
+
+        console.log('Migrated old format watch history', sortedKeys.length);
+        await brwsr.storage.local.remove(sortedKeys);
+        await saveWatchedVideos();
+    }
 }
 
-function loadStorage() {
-    return new Promise(function (resolve, reject) {
-        getStorage().get(null, function (items) {
-            resolve(items);
-        });
-    })
+let lastSyncUpdate = Date.now();
+let saveTimeout;
+async function saveWatchedVideos() {
+    if (Date.now() - lastSyncUpdate < WATCHED_SYNC_THROTTLE) {
+        clearTimeout(saveTimeout);
+        saveTimeout = setTimeout(saveWatchedVideos, WATCHED_SYNC_THROTTLE - (Date.now() - lastSyncUpdate));
+        return;
+    }
+    const batches = {};
+    let currentBatch = [];
+
+    for (const video of watchedVideos) {
+        const key = VIDEO_WATCH_KEY + Object.keys(batches).length;
+        const potentialBatchSize = JSON.stringify({
+            [key]: [...currentBatch, video]
+        }).length;
+
+        // theoretical max size is 8192, but it's safer to have some margin
+        if (potentialBatchSize >= 8000) {
+            if (JSON.stringify({
+                ...batches,
+                [key]: currentBatch
+            }).length > 100000) {
+                // quota exhausted, older entries will be discarded
+                break;
+            }
+
+            batches[key] = currentBatch;
+            currentBatch = [];
+        }
+
+        currentBatch.push(video);
+    }
+    if (currentBatch.length > 0) {
+        batches[VIDEO_WATCH_KEY + Object.keys(batches).length] = currentBatch;
+    }
+
+    try {
+        await brwsr.storage.sync.set(batches);
+        lastSyncUpdate = Date.now();
+    }
+    catch (error) {
+        console.error(error || (typeof runtime !== 'undefined' && runtime.lastError));
+    }
 }
 
-function getSyncStorage() {
-    return brwsr.storage.sync;
-}
+brwsr.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName !== 'sync') {
+        return;
+    }
 
-function setVideoInStorage(videoId) {
-    let obj = {};
-    obj[videoId] = Date.now();
-    getStorage().set(obj);
-}
+    loadWatchedVideos();
+});
 
 function getCurrentPage() {
     let path = window.location.pathname;

--- a/common.js
+++ b/common.js
@@ -34,6 +34,10 @@ try {
 let watchedVideos = {};
 
 async function saveVideoOperation(videoOperation, now) {
+    if (watchedVideos[videoOperation]) {
+        return;
+    }
+
     now = now || Date.now();
 
     const operation = videoOperation.slice(0, 1);

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,8 @@
   "version": "0.17.5",
   "browser_specific_settings": {
     "gecko": {
-      "id": "{5dc6dafa-584e-424a-bf90-1d1d8cfa3caa}"
+      "id": "{5dc6dafa-584e-424a-bf90-1d1d8cfa3caa}",
+      "strict_min_version": "55.0"
     }
   },
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "manifest_version": 2,
   "name": "Better Subscriptions for YouTube™",
   "version": "0.17.5",
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "{5dc6dafa-584e-424a-bf90-1d1d8cfa3caa}"
     }

--- a/pageHandler.js
+++ b/pageHandler.js
@@ -9,7 +9,7 @@ function initExtension() {
         "home": ""
     });
 
-    function handlePageChange() {
+    async function handlePageChange() {
         //remove trailing /
         let page = getCurrentPage();
 
@@ -22,7 +22,7 @@ function initExtension() {
             //handle new page
             switch (page) {
                 case PAGES.subscriptions:
-                    initSubs();
+                    await initSubs();
                     break;
                 case PAGES.video:
                     onVideoPage();
@@ -34,7 +34,7 @@ function initExtension() {
                     if (page.includes(PAGES.short)) {
                         onShortPage();
                     } else if (page.includes(PAGES.channel) && settings["settings.hide.watched.support.channel"]) {
-                        initSubs();
+                        await initSubs();
                     }
             }
         } catch (e) {

--- a/settingsLoader.js
+++ b/settingsLoader.js
@@ -4,7 +4,7 @@ let settingsLoadedCallbacks = [];
 
 let settingsLoaded = false;
 
-getSyncStorage().get(SETTINGS_KEY, items => {
+brwsr.storage.sync.get(SETTINGS_KEY, items => {
     log("Settings loaded:");
     log(items[SETTINGS_KEY]);
     settingsLoaded = true;

--- a/subs.js
+++ b/subs.js
@@ -1,4 +1,3 @@
-let storage = {};
 let hidden = [];
 let hideWatched = null;
 let hidePremieres = null;
@@ -79,52 +78,35 @@ function getVideoTitle(item) {
     return item.querySelector("#video-title").title;
 }
 
-function storageChangeCallback(changes, area) {
-    if (area === "local") {
-        for (let key in changes) {
-            let newValue = changes[key].newValue;
-            if (newValue != null) { // is new added
-                storage[key] = newValue;
-            } else { // is removed
-                delete storage[key];
-            }
-        }
-    }
-}
-
-function initSubs() {
+async function initSubs() {
     log("Initializing subs page...");
 
-    loadStorage().then(function (items) {
-        storage = items;
+    await loadWatchedVideos();
 
-        if (hideWatched == null || !settings["settings.hide.watched.keep.state"]) {
-            hideWatched = settings["settings.hide.watched.default"];
-        }
-        if (hidePremieres == null) {
-            hidePremieres = settings["settings.hide.premieres"];
-        }
-        if (hideShorts == null) {
-            hideShorts = settings["settings.hide.shorts"];
-        }
+    if (hideWatched == null || !settings["settings.hide.watched.keep.state"]) {
+        hideWatched = settings["settings.hide.watched.default"];
+    }
+    if (hidePremieres == null) {
+        hidePremieres = settings["settings.hide.premieres"];
+    }
+    if (hideShorts == null) {
+        hideShorts = settings["settings.hide.shorts"];
+    }
 
-        buildUI();
+    buildUI();
 
-        brwsr.storage.onChanged.addListener(storageChangeCallback);
-
-        intervalId = window.setInterval(function () {
-            if (hideWatched) {
-                try {
-                    removeWatchedAndAddButton();
-                } catch (e) {
-                    logError(e);
-                }
+    intervalId = window.setInterval(function () {
+        if (hideWatched) {
+            try {
+                removeWatchedAndAddButton();
+            } catch (e) {
+                logError(e);
             }
-        }, settings["settings.hide.watched.refresh.rate"]);
+        }
+    }, settings["settings.hide.watched.refresh.rate"]);
 
-        removeWatchedAndAddButton();
+    removeWatchedAndAddButton();
 
-    });
     log("Initializing subs page... DONE");
 }
 
@@ -132,6 +114,5 @@ function stopSubs() {
     log("Stopping subs page behaviour");
 
     removeUI();
-    brwsr.storage.onChanged.removeListener(storageChangeCallback);
     window.clearInterval(intervalId);
 }

--- a/vid.js
+++ b/vid.js
@@ -3,7 +3,8 @@ function onVideoPage() {
         let videoId = new URL(window.location.href).searchParams.get("v");
 
         log("Marking video " + videoId + " as watched from video page");
-        setVideoInStorage(videoId);
+        watchedVideos.unshift(videoId);
+        saveWatchedVideos();
     }
 }
 
@@ -12,6 +13,7 @@ function onShortPage() {
         let videoId = getCurrentPage().split('/')[2];
 
         log("Marking short " + videoId + " as watched from shorts page");
-        setVideoInStorage(videoId);
+        watchedVideos.unshift(videoId);
+        saveWatchedVideos();
     }
 }

--- a/vid.js
+++ b/vid.js
@@ -3,8 +3,8 @@ function onVideoPage() {
         let videoId = new URL(window.location.href).searchParams.get("v");
 
         log("Marking video " + videoId + " as watched from video page");
-        watchedVideos.unshift(videoId);
-        saveWatchedVideos();
+        watchVideo(videoId);
+        syncWatchedVideos();
     }
 }
 
@@ -13,7 +13,7 @@ function onShortPage() {
         let videoId = getCurrentPage().split('/')[2];
 
         log("Marking short " + videoId + " as watched from shorts page");
-        watchedVideos.unshift(videoId);
-        saveWatchedVideos();
+        watchVideo(videoId);
+        syncWatchedVideos();
     }
 }

--- a/videos/Video.js
+++ b/videos/Video.js
@@ -31,7 +31,7 @@ class Video {
     constructor(containingDiv) {
         this.containingDiv = containingDiv;
         this.videoId = getVideoId(containingDiv);
-        this.isStored = watchedVideos.includes(this.videoId);
+        this.isStored = watchedVideos['w' + this.videoId];
         this.buttonId = this.isStored ? MARK_UNWATCHED_BTN : MARK_WATCHED_BTN;
 
         log("Checking video " + this.videoId + " for premiere");
@@ -75,17 +75,14 @@ class Video {
         }
 
         this.isStored = true;
-        if (!watchedVideos.includes(this.videoId)) {
-            watchedVideos.unshift(this.videoId);
-            saveWatchedVideos();
-        }
+
+        watchVideo(this.videoId);
+        syncWatchedVideos();
     }
 
     markUnwatched() {
-        if (watchedVideos.includes(this.videoId)) {
-            watchedVideos.splice(watchedVideos.indexOf(this.videoId), 1);
+        unwatchVideo(this.videoId);
 
-            saveWatchedVideos();
-        }
+        syncWatchedVideos();
     }
 }

--- a/videos/Video.js
+++ b/videos/Video.js
@@ -31,7 +31,7 @@ class Video {
     constructor(containingDiv) {
         this.containingDiv = containingDiv;
         this.videoId = getVideoId(containingDiv);
-        this.isStored = this.videoId in storage;
+        this.isStored = watchedVideos.includes(this.videoId);
         this.buttonId = this.isStored ? MARK_UNWATCHED_BTN : MARK_WATCHED_BTN;
 
         log("Checking video " + this.videoId + " for premiere");
@@ -74,11 +74,18 @@ class Video {
             processSections();
         }
 
-        setVideoInStorage(this.videoId);
         this.isStored = true;
+        if (!watchedVideos.includes(this.videoId)) {
+            watchedVideos.unshift(this.videoId);
+            saveWatchedVideos();
+        }
     }
 
     markUnwatched() {
-        getStorage().remove(this.videoId);
+        if (watchedVideos.includes(this.videoId)) {
+            watchedVideos.splice(watchedVideos.indexOf(this.videoId), 1);
+
+            saveWatchedVideos();
+        }
     }
 }


### PR DESCRIPTION
Fixes #20, #22, #131.

In this PR, the watch history is limited to ~6.5k videos (the limit could be increased if we'd compress the watch history). After this amount is reached, when new entries are added, the oldest entries will be deleted automatically. This way there's no need for a time-based settings to limit the watch history and for most users (other than shorts?), the watch history is basically unlimited.

Added `strict_min_version` to make sure `async/await` is supported. Firefox 55 is released in 2017.

Extension's local watch history will be ported automatically and the import feature can use old export files.