### PR TITLE
Enable UI for channel's live video history

### DIFF
--- a/pageHandler.js
+++ b/pageHandler.js
@@ -6,6 +6,7 @@ function initExtension() {
         "video": "/watch",
         "short": "/shorts",
         "channel": "/videos",
+        "channelLive": "/streams",
         "home": ""
     });
 
@@ -33,7 +34,7 @@ function initExtension() {
                 default:
                     if (page.includes(PAGES.short)) {
                         onShortPage();
-                    } else if (page.includes(PAGES.channel) && settings["settings.hide.watched.support.channel"]) {
+                    } else if ((page.includes(PAGES.channel) || page.includes(PAGES.channelLive)) && settings["settings.hide.watched.support.channel"]) {
                         initSubs();
                     }
             }


### PR DESCRIPTION
Currently, the UI is not enabled for channels' live videos (eg. https://www.youtube.com/@LinusTechTips/streams) and can't be marked as watched in bulk, but these videos still get shown on the subscriptions page.