### PR TITLE
 Publish extension via Github Actions

### DIFF
--- a/.github/workflows/publish-on-chrome-webstore.yml
+++ b/.github/workflows/publish-on-chrome-webstore.yml
@@ -1,0 +1,105 @@
+name: publish-on-chrome-web-store
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        description: Release tag to be published
+        required: true
+      attemptNumber:
+        description: 'Attempt number'
+        required: false
+        default: '1'
+      maxAttempts:
+        description: 'Max attempts'
+        required: false
+        default: '10'
+      environment:
+        description: 'publish-on-webstore job environment'
+        required: false
+        default: ''
+jobs:
+  publish-on-webstore:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment }}
+    steps:
+      - name: Get the next attempt number
+        id: getNextAttemptNumber
+        uses: cardinalby/js-eval-action@v1
+        env:
+          attemptNumber: ${{ github.event.inputs.attemptNumber }}
+          maxAttempts: ${{ github.event.inputs.maxAttempts }}
+        with:
+          expression: |
+            {
+              const 
+                attempt = parseInt(env.attemptNumber),
+                max = parseInt(env.maxAttempts);
+              assert(attempt && max && max >= attempt);
+              return attempt < max ? attempt + 1 : '';
+            }
+
+      - uses: actions/checkout@v2
+
+      - uses: robinraju/release-downloader@v1.8
+        id: download
+        with: 
+          tag: ${{ github.event.inputs.tag }}
+          fileName: yt-better-subscriptions-*.zip
+          tarBall: false
+          zipBall: false
+          extract: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch Google API access token
+        id: fetchAccessToken
+        uses: cardinalby/google-api-fetch-token-action@v1
+        with:
+          clientId: ${{ secrets.G_CLIENT_ID }}
+          clientSecret: ${{ secrets.G_CLIENT_SECRET }}
+          refreshToken: ${{ secrets.G_REFRESH_TOKEN }}
+
+      - name: Upload to Google Web Store
+        id: webStoreUpload
+        continue-on-error: true
+        uses: cardinalby/webext-buildtools-chrome-webstore-upload-action@v1
+        with:
+          zipFilePath: ${{ fromJson(steps.download.outputs.downloaded_files)[0] }}
+          extensionId: ${{ secrets.G_EXTENSION_ID }}
+          apiAccessToken: ${{ steps.fetchAccessToken.outputs.accessToken }}
+          waitForUploadCheckCount: 10
+          waitForUploadCheckIntervalMs: 180000    # 3 minutes
+
+      # Schedule a next attempt if store refused to accept new version because it
+      # still has a previous one in review
+      - name: Start the next attempt with the delay
+        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 # pin@v2
+        if: |
+          steps.getNextAttemptNumber.outputs.result && 
+          steps.webStoreUpload.outputs.inReviewError == 'true'
+        with:
+          workflow: ${{ github.workflow }}
+          token: ${{ secrets.WORKFLOWS_TOKEN }}
+          wait-for-completion: false
+          inputs: |
+            { 
+              "attemptNumber": "${{ steps.getNextAttemptNumber.outputs.result }}",
+              "maxAttempts": "${{ github.event.inputs.maxAttempts }}",
+              "environment": "12hoursDelay"
+            }
+
+      - name: Abort on unrecoverable upload error
+        if: |
+          !steps.webStoreUpload.outputs.newVersion &&
+          steps.webStoreUpload.outputs.sameVersionAlreadyUploadedError != 'true'
+        run: exit 1
+
+      - name: Publish on Google Web Store
+        id: webStorePublish
+        if: |
+          steps.webStoreUpload.outputs.newVersion ||
+          steps.webStoreUpload.outputs.sameVersionAlreadyUploadedError == 'true'
+        uses: cardinalby/webext-buildtools-chrome-webstore-publish-action@v1
+        with:
+          extensionId: ${{ secrets.G_EXTENSION_ID }}
+          apiAccessToken: ${{ steps.fetchAccessToken.outputs.accessToken }}

--- a/.github/workflows/publish-on-chrome-webstore.yml
+++ b/.github/workflows/publish-on-chrome-webstore.yml
@@ -73,7 +73,7 @@ jobs:
       # Schedule a next attempt if store refused to accept new version because it
       # still has a previous one in review
       - name: Start the next attempt with the delay
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 # pin@v2
+        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7 # pin@v1
         if: |
           steps.getNextAttemptNumber.outputs.result && 
           steps.webStoreUpload.outputs.inReviewError == 'true'

--- a/.github/workflows/publish-on-firefox-add-ons.yml
+++ b/.github/workflows/publish-on-firefox-add-ons.yml
@@ -1,0 +1,40 @@
+name: publish-on-firefox-add-ons
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        description: Release tag to be published
+        required: true
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: robinraju/release-downloader@v1.8
+        id: download
+        with: 
+          tag: ${{ github.event.inputs.tag }}
+          fileName: yt-better-subscriptions-*.zip
+          tarBall: false
+          zipBall: false
+          extract: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy to Firefox Addons
+        id: addonsDeploy
+        uses: cardinalby/webext-buildtools-firefox-addons-action@v1
+        continue-on-error: true
+        with:
+          zipFilePath: ${{ fromJson(steps.download.outputs.downloaded_files)[0] }}
+          extensionId: ${{ secrets.FF_EXTENSION_ID }}
+          jwtIssuer: ${{ secrets.FF_JWT_ISSUER }}
+          jwtSecret: ${{ secrets.FF_JWT_SECRET }}
+
+      - name: Abort on upload error
+        if: |
+          steps.addonsDeploy.outcome == 'failure' &&
+          steps.addonsDeploy.outputs.sameVersionAlreadyUploadedError != 'true' &&
+          steps.addonsDeploy.outputs.timeoutError != 'true'
+        run: exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         
+      - name: Validate manifest.json
+        uses: cardinalby/schema-validator-action@v1
+        with:
+          file: manifest.json
+          schema: 'https://json.schemastore.org/webextension.json'
+
       - name: Pack extension ZIP
         uses: TheDoctor0/zip-release@v0.3.0
         with:
@@ -45,3 +51,30 @@ jobs:
           asset_path: ./yt-better-subscriptions-latest.zip
           asset_name: yt-better-subscriptions-${{ steps.get_version.outputs.VERSION }}.zip
           asset_content_type: application/zip
+
+      - name: Publish on Chrome Webstore
+        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7 # pin@v1
+        if: "!contains(github.event.head_commit.message, '[skip chrome]')"
+        with:
+          workflow: publish-on-chrome-web-store
+          token: ${{ secrets.WORKFLOWS_TOKEN }}
+          inputs: '{ "tag": "${{ steps.get_version.outputs.VERSION }}" }'
+          wait-for-completion: false
+
+      - name: Publish on Firefox Add-ons
+        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7 # pin@v1
+        if: "!contains(github.event.head_commit.message, '[skip firefox]')"
+        with:
+          workflow: publish-on-firefox-add-ons
+          token: ${{ secrets.WORKFLOWS_TOKEN }}
+          inputs: '{ "tag": "${{ steps.get_version.outputs.VERSION }}" }'
+          wait-for-completion: false
+
+      # - name: Publish on Edge Add-ons
+      #   uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7 # pin@v1
+      #   if: "!contains(github.event.head_commit.message, '[skip edge]')"
+      #   with:
+      #     workflow: publish-on-edge-add-ons
+      #     token: ${{ secrets.WORKFLOWS_TOKEN }}
+      #     inputs: '{ "tag": "${{ steps.get_version.outputs.VERSION }}" }'
+      #     wait-for-completion: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_OUTPUT
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/touch-google-refresh-token.yml
+++ b/.github/workflows/touch-google-refresh-token.yml
@@ -1,0 +1,19 @@
+name: Touch google token
+on:
+  schedule:
+    - cron:  '0 0 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  fetchToken:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cardinalby/google-api-fetch-token-action@v1
+        with:
+          clientId: ${{ secrets.G_CLIENT_ID }}
+          clientSecret: ${{ secrets.G_CLIENT_SECRET }}
+          refreshToken: ${{ secrets.G_REFRESH_TOKEN }}
+      - uses: gautamkrishnar/keepalive-workflow@v1


### PR DESCRIPTION
Fixes #158, #61

Scheduled Github actions on public repositories are disabled after 60 days of repo inactivity. To keep the Google token scheduled action active, `gautamkrishnar/keepalive-workflow` will create a commit on master after 50 days of inactivity.

Since the Chrome web store may require multiple retries, `workflow_dispatch` was used as `workflow_call` is allowed to have only [4 nested calls](https://docs.github.com/en/actions/using-workflows/reusing-workflows#nesting-reusable-workflows) (retries in our case).

Here's what repo settings need to be made for these workflows to work (securely):

1. Add Protected tags rule for `v*` [here](https://github.com/OsaSoft/youtube-better-subscriptions/settings/tag_protection)
2. Add Branch protection rule for `master` [here](https://github.com/OsaSoft/youtube-better-subscriptions/settings/branches) (make sure `Require a pull request before merging` is disabled as this will block gautamkrishnar/keepalive-workflow)
	- I strongly recommend enabling `Restrict who can push to matching branches` for the master branch if it's not already on
3. Create "12hoursDelay" [environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#creating-an-environment)
	- make sure to select "Select Wait timer" with 720 minutes of wait time
4. Set the following secrets:

##### Github
- secrets required:
	- WORKFLOWS_TOKEN: A GitHub access token (personal access tokens) with write access to the repo. The automatically provided token e.g. `${{ secrets.GITHUB_TOKEN }}` can not be used as GitHub [prevents](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token) this token from being able to fire the `workflow_dispatch`.

##### Firefox Add-ons
[Get Firefox Add-ons keys](https://addons-server.readthedocs.io/en/latest/topics/api/auth.html)
- secrets required:
	- FF_EXTENSION_ID - extension's page at Add-on Developer Hub in the "Technical Details" section
	- FF_JWT_ISSUER
	- FF_JWT_SECRET

##### Chrome Web Store
[Get Google API Keys](https://github.com/fregante/chrome-webstore-upload/blob/main/How%20to%20generate%20Google%20API%20keys.md)
- secrets required:
  - G_CLIENT_ID
  - G_CLIENT_SECRET
  - G_REFRESH_TOKEN

---

I've done no testing, but the workflows were adapted from the [article](https://dev.to/cardinalby/webextension-deployment-and-publishing-using-github-actions-522o) mentioned in a previous comment, so I expect it to work with minimal troubleshooting.