### PR TITLE
Fix #165

### DIFF
--- a/common.js
+++ b/common.js
@@ -33,6 +33,17 @@ try {
 
 let watchedVideos = {};
 
+async function syncStorageGet(keys) {
+    return new Promise((resolve) => {
+        brwsr.storage.sync.get(keys, resolve);
+    });
+}
+async function localStorageGet(keys) {
+    return new Promise((resolve) => {
+        brwsr.storage.local.get(keys, resolve);
+    });
+}
+
 async function saveVideoOperation(videoOperation, now) {
     if (watchedVideos[videoOperation]) {
         return;
@@ -58,7 +69,7 @@ function unwatchVideo(videoId, now) {
 }
 
 async function loadWatchedVideos() {
-    const items = await brwsr.storage.sync.get(null);
+    const items = await syncStorageGet(null);
     const batches = [];
 
     for (const key in items) {
@@ -80,7 +91,7 @@ async function loadWatchedVideos() {
         operations.push(...batch);
     }
 
-    watchedVideos = (await brwsr.storage.local.get(null)) || {};
+    watchedVideos = (await localStorageGet(null)) || {};
 
     const now = Date.now() - operations.length;
     for (const [index, operation] of operations.entries()) {
@@ -146,7 +157,9 @@ async function syncWatchedVideos() {
     }
 
     try {
-        await brwsr.storage.sync.set(batches);
+        await new Promise(resolve => {
+            brwsr.storage.sync.set(batches, resolve);
+        });
         lastSyncUpdate = Date.now();
     }
     catch (error) {

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -120,7 +120,7 @@ async function clearVideos() {
         brwsr.storage.local.clear();
 
         await Promise.all(
-            Object.keys((await brwsr.storage.sync.get(null)) || {}).map(key => {
+            Object.keys((await syncStorageGet(null)) || {}).map(key => {
                 if (key.indexOf(VIDEO_WATCH_KEY) === 0) {
                     brwsr.storage.sync.remove(key);
                 }


### PR DESCRIPTION
Fix #165

Only Chrome manifest v3 extensions support Promise API for storage objects, so using callbacks for now.