### PR TITLE
Add slider for setting number of columns in gridview (and thumbnail size)

### DIFF
--- a/subs-ui.js
+++ b/subs-ui.js
@@ -2,7 +2,8 @@ const HIDE_WATCHED_TOGGLE = PREFIX + "hide-watched-toggle";
 const HIDE_WATCHED_LABEL = PREFIX + "hide-watched-toggle-label";
 const MARK_ALL_WATCHED_BTN = PREFIX + "subs-grid-menu-mark-all";
 const SETTINGS_BTN = PREFIX + "subs-grid-menu-settings";
-const GRID_COLUMN_SIZE_SLIDER = PREFIX + "subs-grid-menu-grid-column-size-slider";
+const GRID_ITEMS_PER_ROW = PREFIX + "subs-grid-menu-grid-column-size-slider";
+const GRID_ITEMS_PER_ROW_VALUE = PREFIX + "subs-grid-menu-grid-column-size-slider-value";
 const MARK_WATCHED_BTN = PREFIX + "mark-watched";
 const MARK_UNWATCHED_BTN = PREFIX + "mark-unwatched";
 const METADATA_LINE = PREFIX + "metadata-line";
@@ -70,24 +71,30 @@ function addSettingsButton() {
 }
 
 function addThumbSizeSlider() {
-    if (gridColumnSize) {
+    if (gridItemsPerRow) {
         let sliderContainer = buildMenuButtonContainer();
-        sliderContainer.setAttribute("id", GRID_COLUMN_SIZE_SLIDER)
+        sliderContainer.setAttribute("id", GRID_ITEMS_PER_ROW);
 
         let slider = document.createElement("input");
         slider.setAttribute("type", "range");
-        slider.setAttribute("min", "5");
-        slider.setAttribute("max", "60");
-        // slider.setAttribute("step", "5");
-        slider.setAttribute("value", gridColumnSize.slice(0,-1));
+        slider.setAttribute("min", "1");
+        slider.setAttribute("max", "20");
+        slider.setAttribute("value", gridItemsPerRow);
         slider.classList.add("subs-grid-menu-thumb-size-slider");
 
         slider.addEventListener("input", (event) => {
             updateGridColumnSize(event.target.value);
         });
 
-        sliderContainer.appendChild(document.createTextNode("(BETA) Thumbnail size")); //TODO: translations
+        let sliderValue = document.createElement("span");
+        sliderValue.setAttribute("id", GRID_ITEMS_PER_ROW_VALUE);
+        sliderValue.innerText  = gridItemsPerRow;
+
+        sliderContainer.appendChild(document.createTextNode("(BETA) Videos per row: "));
+        sliderContainer.appendChild(sliderValue);
+
         sliderContainer.appendChild(slider);
+
         addElementToMenuUI(sliderContainer);
     }
 }

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -2,6 +2,7 @@ const HIDE_WATCHED_TOGGLE = PREFIX + "hide-watched-toggle";
 const HIDE_WATCHED_LABEL = PREFIX + "hide-watched-toggle-label";
 const MARK_ALL_WATCHED_BTN = PREFIX + "subs-grid-menu-mark-all";
 const SETTINGS_BTN = PREFIX + "subs-grid-menu-settings";
+const GRID_COLUMN_SIZE_SLIDER = PREFIX + "subs-grid-menu-grid-column-size-slider";
 const MARK_WATCHED_BTN = PREFIX + "mark-watched";
 const MARK_UNWATCHED_BTN = PREFIX + "mark-unwatched";
 const METADATA_LINE = PREFIX + "metadata-line";
@@ -30,6 +31,7 @@ function buildUI() {
     addHideWatchedCheckbox();
     addHideAllMenuButton();
     addSettingsButton();
+    addThumbSizeSlider();
 
     if (settings["settings.hide.watched.ui.stick.right"])
         addedElems[0].after(...addedElems)
@@ -65,6 +67,29 @@ function addSettingsButton() {
 
     let messenger = document.getElementById(SETTINGS_BTN);
     messenger.addEventListener("click", () => brwsr.runtime.sendMessage({"action": "openOptionsPage"}));
+}
+
+function addThumbSizeSlider() {
+    if (gridColumnSize) {
+        let sliderContainer = buildMenuButtonContainer();
+        sliderContainer.setAttribute("id", GRID_COLUMN_SIZE_SLIDER)
+
+        let slider = document.createElement("input");
+        slider.setAttribute("type", "range");
+        slider.setAttribute("min", "5");
+        slider.setAttribute("max", "60");
+        // slider.setAttribute("step", "5");
+        slider.setAttribute("value", gridColumnSize.slice(0,-1));
+        slider.classList.add("subs-grid-menu-thumb-size-slider");
+
+        slider.addEventListener("input", (event) => {
+            updateGridColumnSize(event.target.value);
+        });
+
+        sliderContainer.appendChild(document.createTextNode("(BETA) Thumbnail size")); //TODO: translations
+        sliderContainer.appendChild(slider);
+        addElementToMenuUI(sliderContainer);
+    }
 }
 
 function addHideAllMenuButton() {

--- a/subs.css
+++ b/subs.css
@@ -91,7 +91,7 @@ ytd-grid-video-renderer.style-scope.ytd-grid-renderer:hover .subs-btn-mark-watch
 
 ytd-two-column-browse-results-renderer > #primary > ytd-rich-grid-renderer > #contents {
   display: grid;
-  grid-template-columns: repeat(var(--ytd-rich-grid-items-per-row), 1fr);
+  grid-template-columns: repeat(auto-fill, var(--osasoft-better-subscriptions-thumb-column-size, 25%));
   max-width: var(--ytd-rich-grid-content-max-width);
   width: calc(100% - 48px);
 }

--- a/subs.css
+++ b/subs.css
@@ -1,3 +1,7 @@
+:root {
+  --osasoft-better-subscriptions-thumb-items-per-row: var(--ytd-rich-grid-items-per-row);
+}
+
 .subs-btn-settings {
   height: 24px;
   padding: 0 10pt !important;
@@ -91,7 +95,7 @@ ytd-grid-video-renderer.style-scope.ytd-grid-renderer:hover .subs-btn-mark-watch
 
 ytd-two-column-browse-results-renderer > #primary > ytd-rich-grid-renderer > #contents {
   display: grid;
-  grid-template-columns: repeat(auto-fill, var(--osasoft-better-subscriptions-thumb-column-size, 25%));
+  grid-template-columns: repeat(var(--osasoft-better-subscriptions-thumb-items-per-row), 1fr);
   max-width: var(--ytd-rich-grid-content-max-width);
   width: calc(100% - 48px);
 }

--- a/subs.js
+++ b/subs.js
@@ -3,6 +3,7 @@ let hideWatched = null;
 let hidePremieres = null;
 let hideShorts = null;
 let intervalId = null;
+let gridColumnSize = null;
 
 function isYouTubeWatched(item) {
     let ytWatchedPercentThreshold = settings["settings.mark.watched.youtube.watched"];
@@ -78,10 +79,14 @@ function getVideoTitle(item) {
     return item.querySelector("#video-title").title;
 }
 
+function updateGridColumnSize(ytGridColumnPercent) {
+    gridColumnSize = `${ytGridColumnPercent}%`;
+    document.documentElement.style
+            .setProperty('--osasoft-better-subscriptions-thumb-column-size', gridColumnSize);
+}
+
 async function initSubs() {
     log("Initializing subs page...");
-
-    await loadWatchedVideos();
 
     if (hideWatched == null || !settings["settings.hide.watched.keep.state"]) {
         hideWatched = settings["settings.hide.watched.default"];
@@ -92,8 +97,15 @@ async function initSubs() {
     if (hideShorts == null) {
         hideShorts = settings["settings.hide.shorts"];
     }
+    if (gridColumnSize == null) {
+        let ytGridItemsPerRow = getComputedStyle(document.documentElement)
+                .getPropertyValue('--ytd-rich-grid-items-per-row');
+        updateGridColumnSize(100 / ytGridItemsPerRow);
+    }
 
     buildUI();
+
+    await loadWatchedVideos();
 
     intervalId = window.setInterval(function () {
         if (hideWatched) {

--- a/subs.js
+++ b/subs.js
@@ -3,7 +3,7 @@ let hideWatched = null;
 let hidePremieres = null;
 let hideShorts = null;
 let intervalId = null;
-let gridColumnSize = null;
+let gridItemsPerRow = null;
 
 function isYouTubeWatched(item) {
     let ytWatchedPercentThreshold = settings["settings.mark.watched.youtube.watched"];
@@ -80,9 +80,14 @@ function getVideoTitle(item) {
 }
 
 function updateGridColumnSize(ytGridColumnPercent) {
-    gridColumnSize = `${ytGridColumnPercent}%`;
+    gridItemsPerRow = `${ytGridColumnPercent}`;
     document.documentElement.style
-            .setProperty('--osasoft-better-subscriptions-thumb-column-size', gridColumnSize);
+            .setProperty('--osasoft-better-subscriptions-thumb-items-per-row', gridItemsPerRow);
+
+    let gridSliderValueElement = document.getElementById(GRID_ITEMS_PER_ROW_VALUE);
+    if (gridSliderValueElement) {
+        gridSliderValueElement.innerText = gridItemsPerRow;
+    }
 }
 
 async function initSubs() {
@@ -97,10 +102,10 @@ async function initSubs() {
     if (hideShorts == null) {
         hideShorts = settings["settings.hide.shorts"];
     }
-    if (gridColumnSize == null) {
+    if (gridItemsPerRow == null) {
         let ytGridItemsPerRow = getComputedStyle(document.documentElement)
-                .getPropertyValue('--ytd-rich-grid-items-per-row');
-        updateGridColumnSize(100 / ytGridItemsPerRow);
+                .getPropertyValue('--osasoft-better-subscriptions-thumb-items-per-row');
+        updateGridColumnSize(ytGridItemsPerRow);
     }
 
     buildUI();


### PR DESCRIPTION
Since a few people have commented on how they would like smaller and more thumbnails per row, I've implemented a simple slider that can adjust this.
This should resolve #153 and #154 and possibly also allow better support for ultra wide as requested in #137 

By default it should take the value YT chooses (based on screen size and resolution, I guess) and for now there is no persistence to the value set (ie. refresh causes it to go back to YT default), but it works when clicking through different pages directly as YT stays on a single "page" when doing so.
Question for review: Does it make sense to ship this as BETA without the save functionality?

![obrazek](https://github.com/OsaSoft/youtube-better-subscriptions/assets/8895463/f089603b-2f6a-4f3a-b031-9880846d1b20)

![obrazek](https://github.com/OsaSoft/youtube-better-subscriptions/assets/8895463/78adcf5d-47a4-4416-b4ac-9f41ab09135d)


