### PR TITLE
Hide Older Videos - Feature Addition

### DIFF
--- a/common.js
+++ b/common.js
@@ -2,11 +2,9 @@ const PREFIX = "osasoft-better-subscriptions_";
 
 const DEFAULT_SETTINGS = {
     "settings.hide.watched.label": true,
-    "settings.hide.older.label": true,
     "settings.hide.watched.all.label": true,
     "settings.hide.watched.ui.stick.right": false,
     "settings.hide.watched.default": true,
-    "settings.hide.older.default": false,
     "settings.hide.watched.keep.state": true,
     "settings.hide.watched.refresh.rate": 3000,
     "settings.mark.watched.youtube.watched": false,
@@ -16,7 +14,8 @@ const DEFAULT_SETTINGS = {
     "settings.hide.watched.auto.store": true,
     "settings.hide.premieres": false,
     "settings.hide.shorts": false,
-    "settings.hide.older.cutoff":"2 Weeks"
+    "settings.hide.older": false,
+    "settings.hide.older.cutoff":"All"
 };
 
 const SETTINGS_KEY = "settings";

--- a/common.js
+++ b/common.js
@@ -6,7 +6,7 @@ const DEFAULT_SETTINGS = {
     "settings.hide.watched.all.label": true,
     "settings.hide.watched.ui.stick.right": false,
     "settings.hide.watched.default": true,
-    "settings.hide.older.default": true,
+    "settings.hide.older.default": false,
     "settings.hide.watched.keep.state": true,
     "settings.hide.watched.refresh.rate": 3000,
     "settings.mark.watched.youtube.watched": false,

--- a/common.js
+++ b/common.js
@@ -2,9 +2,11 @@ const PREFIX = "osasoft-better-subscriptions_";
 
 const DEFAULT_SETTINGS = {
     "settings.hide.watched.label": true,
+    "settings.hide.older.label": true,
     "settings.hide.watched.all.label": true,
     "settings.hide.watched.ui.stick.right": false,
     "settings.hide.watched.default": true,
+    "settings.hide.older.default": true,
     "settings.hide.watched.keep.state": true,
     "settings.hide.watched.refresh.rate": 3000,
     "settings.mark.watched.youtube.watched": false,
@@ -14,6 +16,7 @@ const DEFAULT_SETTINGS = {
     "settings.hide.watched.auto.store": true,
     "settings.hide.premieres": false,
     "settings.hide.shorts": false,
+    "settings.hide.older.cutoff":"2 Weeks"
 };
 
 const SETTINGS_KEY = "settings";

--- a/pageHandler.js
+++ b/pageHandler.js
@@ -1,15 +1,15 @@
 settingsLoadedCallbacks.push(initExtension);
 
-function initExtension() {
-    const PAGES = Object.freeze({
-        "subscriptions": "/feed/subscriptions",
-        "video": "/watch",
-        "short": "/shorts",
-        "channel": "/videos",
-        "channelLive": "/streams",
-        "home": ""
-    });
+const PAGES = Object.freeze({
+    "subscriptions": "/feed/subscriptions",
+    "video": "/watch",
+    "short": "/shorts",
+    "channel": "/videos",
+    "channelLive": "/streams",
+    "home": ""
+});
 
+function initExtension() {
     async function handlePageChange() {
         //remove trailing /
         let page = getCurrentPage();

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -37,6 +37,9 @@
       <input id="settings.hide.watched.label" type="checkbox"/>
       <label for="settings.hide.watched.label">Show "Hide Watched" label</label><br/>
 
+      <input id="settings.hide.older.label" type="checkbox"/>
+      <label for="settings.hide.older.label">Show "Hide Older" label</label><br/>
+
       <input id="settings.hide.watched.all.label" type="checkbox"/>
       <label for="settings.hide.watched.all.label">Show "Mark all as watched" label</label><br/>
 
@@ -46,6 +49,9 @@
 
       <input id="settings.hide.watched.default" type="checkbox"/>
       <label for="settings.hide.watched.default">Hide watched default state</label><br/>
+
+      <input id="settings.hide.older.default" type="checkbox"/>
+      <label for="settings.hide.older.default">Hide older default state</label><br/>
 
       <input id="settings.hide.watched.keep.state" type="checkbox"/>
       <label for="settings.hide.watched.keep.state">
@@ -70,8 +76,16 @@
 
       <label for="settings.hide.watched.refresh.rate">Refresh rate for feed clearing (milliseconds)</label>
       <input id="settings.hide.watched.refresh.rate" type="number"/><br/>
-      <label for="settings.hide.watched.refresh.rate">(currently works only in "hide watched" state)</label>
+      <label for="settings.hide.watched.refresh.rate">(currently works only in "hide watched" state)</label><br/>
+      <br/>
 
+      <label for="settings.hide.older.cutoff">Hide videos older than</label>
+      <select id="settings.hide.older.cutoff">
+        <option value="Today">Today</option>
+        <option value="1 Week">1 Week</option>
+        <option value="2 Weeks">2 Weeks</option>
+        <option value="1 Month">1 Month</option>
+      </select>
     </form>
   </div>
 

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -37,9 +37,6 @@
       <input id="settings.hide.watched.label" type="checkbox"/>
       <label for="settings.hide.watched.label">Show "Hide Watched" label</label><br/>
 
-      <input id="settings.hide.older.label" type="checkbox"/>
-      <label for="settings.hide.older.label">Show "Hide Older" label</label><br/>
-
       <input id="settings.hide.watched.all.label" type="checkbox"/>
       <label for="settings.hide.watched.all.label">Show "Mark all as watched" label</label><br/>
 
@@ -49,9 +46,6 @@
 
       <input id="settings.hide.watched.default" type="checkbox"/>
       <label for="settings.hide.watched.default">Hide watched default state</label><br/>
-
-      <input id="settings.hide.older.default" type="checkbox"/>
-      <label for="settings.hide.older.default">Hide older default state</label><br/>
 
       <input id="settings.hide.watched.keep.state" type="checkbox"/>
       <label for="settings.hide.watched.keep.state">
@@ -74,20 +68,26 @@
       <label for="settings.hide.shorts">Hide Shorts automatically</label><br/>
       <br/>
 
-      <label for="settings.hide.watched.refresh.rate">Refresh rate for feed clearing (milliseconds)</label>
-      <input id="settings.hide.watched.refresh.rate" type="number"/><br/>
-      <label for="settings.hide.watched.refresh.rate">(currently works only in "hide watched" state and when Hiding older videos)</label><br/>
-      <br/>
-
-      <label for="settings.hide.older.cutoff">Hide videos older than</label>
+      <input id="settings.hide.older" type="checkbox"/>
+      <label for="settings.hide.older">Hide older videos </label>
+      <label for="settings.hide.older.cutoff">with default Cutoff: </label>
       <select id="settings.hide.older.cutoff">
+        <option value="All">All</option>
         <option value="Today">Today</option>
         <option value="1 Week">1 Week</option>
         <option value="2 Weeks">2 Weeks</option>
         <option value="1 Month">1 Month</option>
-      </select>
+      </select><br/>
+      <br/>
+
+      <label for="settings.hide.watched.refresh.rate">Refresh rate for feed clearing (milliseconds)</label>
+      <input id="settings.hide.watched.refresh.rate" type="number"/><br/>
+      <label for="settings.hide.watched.refresh.rate">(currently works only in "hide watched" state and when Hiding older videos)</label><br/>
+      <br/>
     </form>
   </div>
+
+
 
   <h2>Other YouTube&trade; pages</h2>
 

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -76,7 +76,7 @@
 
       <label for="settings.hide.watched.refresh.rate">Refresh rate for feed clearing (milliseconds)</label>
       <input id="settings.hide.watched.refresh.rate" type="number"/><br/>
-      <label for="settings.hide.watched.refresh.rate">(currently works only in "hide watched" state)</label><br/>
+      <label for="settings.hide.watched.refresh.rate">(currently works only in "hide watched" state and when Hiding older videos)</label><br/>
       <br/>
 
       <label for="settings.hide.older.cutoff">Hide videos older than</label>

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -46,7 +46,7 @@ function hideSpinners() {
 function saveSettings() {
     let values = {};
 
-    for (let elem of document.querySelectorAll("input[id^='settings.']")) {
+    for (let elem of document.querySelectorAll("input[id^='settings.'], select[id^='settings.']")) {
         if (elem.matches('input[type="checkbox"]')) {
             values[elem.id] = elem.checked;
         } else {

--- a/queries.js
+++ b/queries.js
@@ -1,9 +1,9 @@
 function vidQuery() {
     return [
-        `ytd-grid-video-renderer.style-scope.ytd-grid-renderer:not(.${HIDDEN_CLASS})`,
-        `ytd-rich-item-renderer.style-scope.ytd-rich-grid-renderer:not(.${HIDDEN_CLASS})`,
-        `ytd-rich-item-renderer.style-scope.ytd-rich-grid-row:not(.${HIDDEN_CLASS})`,
-        `ytd-rich-item-renderer.style-scope.ytd-rich-shelf-renderer:not([is-post]):not(.${HIDDEN_CLASS})`
+        `ytd-grid-video-renderer.style-scope.ytd-grid-renderer:not(.${HIDDEN_CLASS}):not(.${OLDER_CLASS})`,
+        `ytd-rich-item-renderer.style-scope.ytd-rich-grid-renderer:not(.${HIDDEN_CLASS}):not(.${OLDER_CLASS})`,
+        `ytd-rich-item-renderer.style-scope.ytd-rich-grid-row:not(.${HIDDEN_CLASS}):not(.${OLDER_CLASS})`,
+        `ytd-rich-item-renderer.style-scope.ytd-rich-shelf-renderer:not([is-post]):not(.${HIDDEN_CLASS}):not(.${OLDER_CLASS})`
     ].join(',');
 }
 

--- a/queries.js
+++ b/queries.js
@@ -22,3 +22,7 @@ function sectionDismissableQuery() {
 function sectionContentsQuery() {
     return "#contents";
 }
+
+function fuzzyDateQuery() {
+    return '#metadata-line>span';
+}

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -143,7 +143,6 @@ function addHideWatchedCheckbox() {
 
 function addHideOlderCutoffSelect() {
     if (hideOlder) {
-        deleteOldButton(HIDE_OLDER_CUTOFF_SELECT)
         let hideOlderCutoffSelect = document.createElement("select");
         hideOlderCutoffSelect.setAttribute("id", HIDE_OLDER_CUTOFF_SELECT);
 
@@ -151,6 +150,7 @@ function addHideOlderCutoffSelect() {
             let option = document.createElement("option");
             option.value = optionText;
             option.textContent = optionText;
+            if (optionText == hideOlderCutoff) option.selected = true;
             hideOlderCutoffSelect.appendChild(option);
         });
 

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -20,7 +20,6 @@ function showWatched() {
 
     for (let item of hidden) {
         item.style.display = '';
-        item.style.visibility = '';
         item.classList.remove(HIDDEN_CLASS);
     }
     hidden = [];
@@ -33,8 +32,10 @@ function showOlder() {
     log("Showing older videos");
 
     for (let item of older) {
-        item.style.display = '';
         item.style.visibility = '';
+        if (! item.classList.contains(HIDDEN_CLASS)) {
+            item.style.display = '';
+        }
         item.classList.remove(OLDER_CLASS);
     }
     older = [];

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -293,7 +293,7 @@ function removeWatchedAndAddButton() {
 
     let els = document.querySelectorAll(vidQuery());
 
-    let haveHidden = false;
+    let hiddenCount = 0;
 
     for (let item of els) {
         let vid = new SubscriptionVideo(item);
@@ -309,7 +309,7 @@ function removeWatchedAndAddButton() {
             (hideShorts && vid.isShort)
         ) {
             vid.hide();
-            haveHidden = true;
+            hiddenCount++;
         }
 
         // does it already have any button?
@@ -335,7 +335,7 @@ function removeWatchedAndAddButton() {
     log("Removing watched from feed and adding overlay... Done");
 
     // if we hid any videos, see if sections need changing, or videos loading
-    if (haveHidden) {
+    if (hiddenCount > 0) {
         processSections();
         loadMoreVideos();
     }

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -253,6 +253,10 @@ function removeWatchedAndAddButton() {
             hiddenCount++;
         }
 
+        if (vid.isOld) {
+            vid.hideOlder();
+        }
+
         // does it already have any button?
         if (!vid.hasButton()) {
             vid.addButton();

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -1,7 +1,6 @@
 const HIDE_WATCHED_TOGGLE = PREFIX + "hide-watched-toggle";
 const HIDE_WATCHED_LABEL = PREFIX + "hide-watched-toggle-label";
-const HIDE_OLDER_TOGGLE = PREFIX + "hide-older-toggle";
-const HIDE_OLDER_LABEL = PREFIX + "hide-older-toggle-label";
+const HIDE_OLDER_CUTOFF_SELECT = PREFIX + "hide-older-cutoff-select";
 const MARK_ALL_WATCHED_BTN = PREFIX + "subs-grid-menu-mark-all";
 const SETTINGS_BTN = PREFIX + "subs-grid-menu-settings";
 const MARK_WATCHED_BTN = PREFIX + "mark-watched";
@@ -12,6 +11,8 @@ const COLLAPSE_SECTION_CHECKBOX = PREFIX + "collapse-section";
 const HIDDEN_CLASS = PREFIX + "hidden";
 const OLDER_CLASS = PREFIX + "older";
 const COLLAPSE_CLASS = PREFIX + "collapse-section";
+
+const HIDE_OLDER_CUTOFF_OPTIONS = ["All", "Today", "1 Week", "2 Weeks", "1 Month"]
 
 let addedElems = [];
 
@@ -46,7 +47,7 @@ function buildUI() {
     log("Building subs UI");
 
     addHideWatchedCheckbox();
-    addHideOlderCheckbox();
+    addHideOlderCutoffSelect();
     addHideAllMenuButton();
     addSettingsButton();
 
@@ -140,45 +141,25 @@ function addHideWatchedCheckbox() {
     messenger.addEventListener("click", hideWatchedChanged);
 }
 
-function addHideOlderCheckbox() {
-    if (settings["settings.hide.older.label"]) {
-        deleteOldButton(HIDE_OLDER_LABEL);
-
-        let hideOlderLabel = buildMenuButtonContainer();
-        hideOlderLabel.setAttribute("id", HIDE_OLDER_LABEL);
-        hideOlderLabel.appendChild(document.createTextNode("Hide older"));
-        addElementToMenuUI(hideOlderLabel);
-
-        let messenger = document.getElementById(HIDE_OLDER_LABEL);
-        messenger.addEventListener("click", hideOlderChanged);
-    }
-
-    deleteOldButton(HIDE_OLDER_TOGGLE);
-
-    let toggleContainer = document.createElement("div");
-    toggleContainer.setAttribute("id", HIDE_OLDER_TOGGLE);
-    toggleContainer.classList.add("toggle-container", "style-scope", "tp-yt-paper-toggle-button");
+function addHideOlderCutoffSelect() {
     if (hideOlder) {
-        toggleContainer.classList.add("subs-btn-hide-older-checked");
-    } else {
-        toggleContainer.classList.add("subs-btn-hide-older-unchecked");
+        deleteOldButton(HIDE_OLDER_CUTOFF_SELECT)
+        let hideOlderCutoffSelect = document.createElement("select");
+        hideOlderCutoffSelect.setAttribute("id", HIDE_OLDER_CUTOFF_SELECT);
+
+        HIDE_OLDER_CUTOFF_OPTIONS.forEach(optionText => {
+            let option = document.createElement("option");
+            option.value = optionText;
+            option.textContent = optionText;
+            hideOlderCutoffSelect.appendChild(option);
+        });
+
+        addElementToMenuUI(hideOlderCutoffSelect);
+
+        let messenger = document.getElementById(HIDE_OLDER_CUTOFF_SELECT);
+        messenger.addEventListener("change", hideOlderChanged);
     }
-
-    let toggleBar = document.createElement("div");
-    toggleBar.classList.add("toggle-bar", "style-scope", "tp-yt-paper-toggle-button");
-    let toggleButton = document.createElement("div");
-    toggleButton.classList.add("toggle-button", "style-scope", "tp-yt-paper-toggle-button");
-
-    toggleContainer.appendChild(toggleBar);
-    toggleContainer.appendChild(toggleButton);
-
-    addElementToMenuUI(toggleContainer);
-
-    let messenger = document.getElementById(HIDE_OLDER_TOGGLE);
-    messenger.addEventListener("click", hideOlderChanged);
-
 }
-
 
 function addElementToMenuUI(element) {
     log("Adding element to menu UI");

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -1,5 +1,7 @@
 const HIDE_WATCHED_TOGGLE = PREFIX + "hide-watched-toggle";
 const HIDE_WATCHED_LABEL = PREFIX + "hide-watched-toggle-label";
+const HIDE_OLDER_TOGGLE = PREFIX + "hide-older-toggle";
+const HIDE_OLDER_LABEL = PREFIX + "hide-older-toggle-label";
 const MARK_ALL_WATCHED_BTN = PREFIX + "subs-grid-menu-mark-all";
 const SETTINGS_BTN = PREFIX + "subs-grid-menu-settings";
 const MARK_WATCHED_BTN = PREFIX + "mark-watched";
@@ -26,15 +28,29 @@ function showWatched() {
     processSections();
 }
 
+
+function showOlder() {
+    log("Showing older videos");
+
+    for (let item of older) {
+        item.style.display = '';
+        item.style.visibility = '';
+        item.classList.remove(OLDER_CLASS);
+    }
+    older = [];
+}
+
+
 function buildUI() {
     log("Building subs UI");
 
     addHideWatchedCheckbox();
+    addHideOlderCheckbox();
     addHideAllMenuButton();
     addSettingsButton();
 
     if (settings["settings.hide.watched.ui.stick.right"])
-        addedElems[0].after(...addedElems)
+        addedElems[0].after(...addedElems);
 }
 
 function buildMenuButtonContainer() {
@@ -43,7 +59,6 @@ function buildMenuButtonContainer() {
     menuButtonContainer.classList.add("yt-simple-endpoint");
     menuButtonContainer.classList.add("style-scope");
     menuButtonContainer.classList.add("ytd-compact-link-renderer");
-
     menuButtonContainer.classList.add("subs-grid-menu-item");
 
     return menuButtonContainer;
@@ -123,6 +138,46 @@ function addHideWatchedCheckbox() {
     let messenger = document.getElementById(HIDE_WATCHED_TOGGLE);
     messenger.addEventListener("click", hideWatchedChanged);
 }
+
+function addHideOlderCheckbox() {
+    if (settings["settings.hide.older.label"]) {
+        deleteOldButton(HIDE_OLDER_LABEL);
+
+        let hideOlderLabel = buildMenuButtonContainer();
+        hideOlderLabel.setAttribute("id", HIDE_OLDER_LABEL);
+        hideOlderLabel.appendChild(document.createTextNode("Hide older"));
+        addElementToMenuUI(hideOlderLabel);
+
+        let messenger = document.getElementById(HIDE_OLDER_LABEL);
+        messenger.addEventListener("click", hideOlderChanged);
+    }
+
+    deleteOldButton(HIDE_OLDER_TOGGLE);
+
+    let toggleContainer = document.createElement("div");
+    toggleContainer.setAttribute("id", HIDE_OLDER_TOGGLE);
+    toggleContainer.classList.add("toggle-container", "style-scope", "tp-yt-paper-toggle-button");
+    if (hideOlder) {
+        toggleContainer.classList.add("subs-btn-hide-older-checked");
+    } else {
+        toggleContainer.classList.add("subs-btn-hide-older-unchecked");
+    }
+
+    let toggleBar = document.createElement("div");
+    toggleBar.classList.add("toggle-bar", "style-scope", "tp-yt-paper-toggle-button");
+    let toggleButton = document.createElement("div");
+    toggleButton.classList.add("toggle-button", "style-scope", "tp-yt-paper-toggle-button");
+
+    toggleContainer.appendChild(toggleBar);
+    toggleContainer.appendChild(toggleButton);
+
+    addElementToMenuUI(toggleContainer);
+
+    let messenger = document.getElementById(HIDE_OLDER_TOGGLE);
+    messenger.addEventListener("click", hideOlderChanged);
+
+}
+
 
 function addElementToMenuUI(element) {
     log("Adding element to menu UI");

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -18,6 +18,7 @@ function showWatched() {
 
     for (let item of hidden) {
         item.style.display = '';
+        item.style.visibility = '';
         item.classList.remove(HIDDEN_CLASS);
     }
     hidden = [];
@@ -237,11 +238,14 @@ function removeWatchedAndAddButton() {
 
     let els = document.querySelectorAll(vidQuery());
 
-    let hiddenCount = 0;
+    let haveHidden = false;
 
     for (let item of els) {
         let vid = new SubscriptionVideo(item);
 
+        if (hideOlder && vid.isOlder){
+            vid.hideOlder();
+        }
         if (!vid.isStored && isYouTubeWatched(item)) {
             vid.markWatched();
         } else if (
@@ -250,11 +254,7 @@ function removeWatchedAndAddButton() {
             (hideShorts && vid.isShort)
         ) {
             vid.hide();
-            hiddenCount++;
-        }
-
-        if (vid.isOld) {
-            vid.hideOlder();
+            haveHidden = true;
         }
 
         // does it already have any button?
@@ -280,7 +280,7 @@ function removeWatchedAndAddButton() {
     log("Removing watched from feed and adding overlay... Done");
 
     // if we hid any videos, see if sections need changing, or videos loading
-    if (hiddenCount > 0) {
+    if (haveHidden) {
         processSections();
         loadMoreVideos();
     }
@@ -301,5 +301,11 @@ function removeUI() {
         item.style.display = '';
         item.classList.remove(HIDDEN_CLASS);
     }
+    for (let item of older) {
+        item.style.display = '';
+        item.style.visibility = '';
+        item.classList.remove(OLDER_CLASS);
+    }
     hidden = [];
+    older = [];
 }

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -8,6 +8,7 @@ const METADATA_LINE = PREFIX + "metadata-line";
 const COLLAPSE_SECTION_CHECKBOX = PREFIX + "collapse-section";
 
 const HIDDEN_CLASS = PREFIX + "hidden";
+const OLDER_CLASS = PREFIX + "older";
 const COLLAPSE_CLASS = PREFIX + "collapse-section";
 
 let addedElems = [];

--- a/subs.css
+++ b/subs.css
@@ -5,12 +5,12 @@
   background-repeat: no-repeat;
 }
 
-.subs-btn-hide-watched-checked, .subs-btn-hide-watched-unchecked, .subs-btn-hide-older-checked, .subs-btn-hide-older-unchecked  {
+.subs-btn-hide-watched-checked, .subs-btn-hide-watched-unchecked { 
   opacity: .8;
   margin: 0 12px !important;
 }
 
-.subs-btn-hide-watched-checked, .subs-btn-hide-older-checked, .toggle-button {
+.subs-btn-hide-watched-checked, .toggle-button {
   background-color: var(--paper-toggle-button-checked-button-color, var(--primary-color));
 
   background-image: url('images/markunwatched.svg'), /*works in Firefox*/ url('chrome-extension://__MSG_@@extension_id__/images/markunwatched.svg'); /*works in Chrome*/
@@ -18,7 +18,7 @@
   transform: translate(16px, 0);
 }
 
-.subs-btn-hide-watched-unchecked, .subs-btn-hide-older-unchecked, .toggle-button {
+.subs-btn-hide-watched-unchecked, .toggle-button {
   background-image: url('images/markwatched.svg'), /*works in Firefox*/ url('chrome-extension://__MSG_@@extension_id__/images/markwatched.svg'); /*works in Chrome*/
   background-size: cover;
 }
@@ -49,12 +49,12 @@
   background-size: cover;
 }
 
-.subs-btn-mark-watched:hover, .subs-btn-mark-unwatched:hover, .subs-btn-hide-watched-checked:hover, .subs-btn-hide-watched-unchecked:hover, .subs-btn-hide-older-checked:hover, .subs-btn-hide-older-unchecked:hover {
+.subs-btn-mark-watched:hover, .subs-btn-mark-unwatched:hover, .subs-btn-hide-watched-checked:hover, .subs-btn-hide-watched-unchecked:hover { 
   opacity: .8;
   cursor: pointer;
 }
 
-.subs-btn-mark-watched:active, .subs-btn-mark-unwatched:active, .subs-btn-hide-watched-checked:active, .subs-btn-hide-watched-unchecked:active, .subs-btn-hide-older-checked:active, .subs-btn-hide-older-unchecked:active {
+.subs-btn-mark-watched:active, .subs-btn-mark-unwatched:active, .subs-btn-hide-watched-checked:active, .subs-btn-hide-watched-unchecked:active { 
   opacity: 1.0;
   cursor: pointer;
 }

--- a/subs.css
+++ b/subs.css
@@ -5,12 +5,12 @@
   background-repeat: no-repeat;
 }
 
-.subs-btn-hide-watched-checked, .subs-btn-hide-watched-unchecked {
+.subs-btn-hide-watched-checked, .subs-btn-hide-watched-unchecked, .subs-btn-hide-older-checked, .subs-btn-hide-older-unchecked  {
   opacity: .8;
   margin: 0 12px !important;
 }
 
-.subs-btn-hide-watched-checked .toggle-button {
+.subs-btn-hide-watched-checked, .subs-btn-hide-older-checked, .toggle-button {
   background-color: var(--paper-toggle-button-checked-button-color, var(--primary-color));
 
   background-image: url('images/markunwatched.svg'), /*works in Firefox*/ url('chrome-extension://__MSG_@@extension_id__/images/markunwatched.svg'); /*works in Chrome*/
@@ -18,7 +18,7 @@
   transform: translate(16px, 0);
 }
 
-.subs-btn-hide-watched-unchecked .toggle-button {
+.subs-btn-hide-watched-unchecked, .subs-btn-hide-older-unchecked, .toggle-button {
   background-image: url('images/markwatched.svg'), /*works in Firefox*/ url('chrome-extension://__MSG_@@extension_id__/images/markwatched.svg'); /*works in Chrome*/
   background-size: cover;
 }
@@ -49,12 +49,12 @@
   background-size: cover;
 }
 
-.subs-btn-mark-watched:hover, .subs-btn-mark-unwatched:hover, .subs-btn-hide-watched-checked:hover, .subs-btn-hide-watched-unchecked:hover {
+.subs-btn-mark-watched:hover, .subs-btn-mark-unwatched:hover, .subs-btn-hide-watched-checked:hover, .subs-btn-hide-watched-unchecked:hover, .subs-btn-hide-older-checked:hover, .subs-btn-hide-older-unchecked:hover {
   opacity: .8;
   cursor: pointer;
 }
 
-.subs-btn-mark-watched:active, .subs-btn-mark-unwatched:active, .subs-btn-hide-watched-checked:active, .subs-btn-hide-watched-unchecked:active {
+.subs-btn-mark-watched:active, .subs-btn-mark-unwatched:active, .subs-btn-hide-watched-checked:active, .subs-btn-hide-watched-unchecked:active, .subs-btn-hide-older-checked:active, .subs-btn-hide-older-unchecked:active {
   opacity: 1.0;
   cursor: pointer;
 }

--- a/subs.js
+++ b/subs.js
@@ -39,20 +39,10 @@ function hideWatchedChanged(event) {
 
 function hideOlderChanged(event) {
     try {
-        let toggle = document.getElementById(HIDE_OLDER_TOGGLE);
-        log("Hide Older checkbox was changed. New value is: " + !hideOlder);
-
-        if (hideOlder) {
-            hideOlder = false;
-            toggle.classList.remove("subs-btn-hide-older-checked");
-            toggle.classList.add("subs-btn-hide-older-unchecked");
-            showOlder();
-        } else {
-            hideOlder = true;
-            toggle.classList.remove("subs-btn-hide-older-unchecked");
-            toggle.classList.add("subs-btn-hide-older-checked");
-            removeWatchedAndAddButton();
-        }
+        let select = document.getElementById(HIDE_OLDER_CUTOFF_SELECT);
+        hideOlderCutoff = select.value;
+        showOlder();
+        removeWatchedAndAddButton();
     } catch (e) {
         logError(e);
     }

--- a/subs.js
+++ b/subs.js
@@ -126,7 +126,7 @@ async function initSubs() {
     buildUI();
 
     intervalId = window.setInterval(function () {
-        if (hideWatched) {
+        if (hideWatched || hideOlder) {
             try {
                 removeWatchedAndAddButton();
             } catch (e) {

--- a/subs.js
+++ b/subs.js
@@ -37,6 +37,27 @@ function hideWatchedChanged(event) {
     }
 }
 
+function hideOlderChanged(event) {
+    try {
+        let toggle = document.getElementById(HIDE_OLDER_TOGGLE);
+        log("Hide Older checkbox was changed. New value is: " + !hideOlder);
+
+        if (hideOlder) {
+            hideOlder = false;
+            toggle.classList.remove("subs-btn-hide-older-checked");
+            toggle.classList.add("subs-btn-hide-older-unchecked");
+            showOlder();
+        } else {
+            hideOlder = true;
+            toggle.classList.remove("subs-btn-hide-older-unchecked");
+            toggle.classList.add("subs-btn-hide-older-checked");
+            removeWatchedAndAddButton();
+        }
+    } catch (e) {
+        logError(e);
+    }
+}
+
 function collapseSectionChanged(event) {
     try {
         let checkbox = event.target;

--- a/subs.js
+++ b/subs.js
@@ -1,7 +1,10 @@
 let hidden = [];
+let older = [];
 let hideWatched = null;
 let hidePremieres = null;
 let hideShorts = null;
+let hideOlder = null;
+let hideOlderCutoff = null;
 let intervalId = null;
 
 function isYouTubeWatched(item) {
@@ -91,6 +94,12 @@ async function initSubs() {
     }
     if (hideShorts == null) {
         hideShorts = settings["settings.hide.shorts"];
+    }
+    if (hideOlder == null) {
+        hideOlder = settings["settings.hide.older"];
+    }
+    if (hideOlderCutoff == null) {
+        hideOlderCutoff = settings["settings.hide.older.cutoff"];
     }
 
     buildUI();

--- a/videos/Video.js
+++ b/videos/Video.js
@@ -100,6 +100,16 @@ class Video {
         this.containingDiv.classList.add(HIDDEN_CLASS);
     }
 
+    hideOlder() {
+        older.push(this.containingDiv);
+        // if on chronological page, take up space to prevent layout shift
+        this.containingDiv.style.visibility = 'hidden';
+        this.containingDiv.classList.add(OLDER_CLASS);
+        // otherwise if on home page, hide and allow continuation of home page feed
+        if (getCurrentPage() == PAGES.home) this.containingDiv.style.display = 'none';
+        // TODO: support setting toggle for hide behavior on various other pages, like channel pages
+    }
+
     markWatched() {
         changeMarkWatchedToMarkUnwatched(this.containingDiv);
 

--- a/videos/Video.js
+++ b/videos/Video.js
@@ -75,7 +75,7 @@ class Video {
                 if (hideOlderCutoff == "Today") {
                     this.isOlder = true;
                 }
-                else if (hideOlderCutoff == "1 Week" && Number(this.fuzzyDate.split(" ")[0]) >= 7) {
+                else if (hideOlderCutoff == "1 Week" && Number(this.fuzzyDate.match(/\d+/)[0]) >= 7) {
                     this.isOlder = true;
                 }
             }

--- a/videos/Video.js
+++ b/videos/Video.js
@@ -61,6 +61,29 @@ class Video {
             log("Video URL is null - ad.");
             this.isShort = true;
         }
+        log('video ' + this.videoId + " associated with date " + this.fuzzyDate)
+        if (this.fuzzyDate != null) {
+            this.isOlder = false;
+            log(this.fuzzyDate)
+            if (this.fuzzyDate.includes("month") || this.fuzzyDate.includes("year")) {
+                this.isOlder = true;
+            }
+            else if (this.fuzzyDate.includes("weeks") && hideOlderCutoff != "1 Month") {
+                this.isOlder = true;
+            }
+            else if (this.fuzzyDate.includes("day")) {
+                if (hideOlderCutoff == "Today") {
+                    this.isOlder = true;
+                }
+                else if (hideOlderCutoff == "1 Week" && Number(this.fuzzyDate.split(" ")[0]) >= 7) {
+                    this.isOlder = true;
+                }
+            }
+        }
+        else{
+            this.isOlder = null;
+        }
+        log(`isOlder: ${this.isOlder} based on cutoff: ${hideOlderCutoff}`)
     }
 
     hasButton() {

--- a/videos/Video.js
+++ b/videos/Video.js
@@ -15,6 +15,16 @@ function getVideoId(item) {
     }
 }
 
+function getVideoFuzzyDate(item) {
+    let videoFuzzyDate = item.querySelectorAll(fuzzyDateQuery())[1];
+    if (videoFuzzyDate != null) {
+        return videoFuzzyDate.innerText;
+    }
+    else {
+        log("Unable to determine video date")
+    }
+}
+
 function changeMarkWatchedToMarkUnwatched(item) {
     // find Mark as watched button and change it to Unmark as watched
     let metaDataLine = item.querySelector("#" + METADATA_LINE);
@@ -33,6 +43,7 @@ class Video {
         this.videoId = getVideoId(containingDiv);
         this.isStored = watchedVideos['w' + this.videoId];
         this.buttonId = this.isStored ? MARK_UNWATCHED_BTN : MARK_WATCHED_BTN;
+        this.fuzzyDate = getVideoFuzzyDate(containingDiv);
 
         log("Checking video " + this.videoId + " for premiere");
         let thumbOverlay = containingDiv.querySelector("ytd-thumbnail-overlay-time-status-renderer");


### PR DESCRIPTION
@OsaSoft - Long time user, first time contributor. Thank you for making this thing!

Addresses #63 Prevent Loading of older videos based on readable dates in video thumbnail container (English Support Only). 

Current Cutoff options are:
- Today
- 1 Week
- 2 Weeks
- 1 Month

On subscriptions page (chronological) it sets older video styles to visibility:hidden, so they still take up space and prevent loading of excess videos. On home feed, it sets older videos styles to display:none to allow for continued loading. 

Mark All Watched only affects visible videos, so no chance marking video that is only hidden due to age as watched by accident.

Basic UI added to header to accomplish this, just following lead of hide watched toggle. The bar is getting quite crowded, so redesign of some sort should be implemented before merge. All UI and UI logic is in [last commit](https://github.com/OsaSoft/youtube-better-subscriptions/commit/baf74c62405ee5e3c4a1e3e0500c807f7a265140) so single rollback of that will maintain functionality using just options page while awaiting redesign. 
#
Thank You!