### PR TITLE
Add Feature - Remove Rich Shelves Entirely

### DIFF
--- a/common.js
+++ b/common.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
     "settings.hide.watched.auto.store": true,
     "settings.hide.premieres": false,
     "settings.hide.shorts": false,
+    "settings.remove.rich.sections": false,
 };
 
 const SETTINGS_KEY = "settings";

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -66,6 +66,9 @@
 
       <input id="settings.hide.shorts" type="checkbox"/>
       <label for="settings.hide.shorts">Hide Shorts automatically</label><br/>
+
+      <input id="settings.remove.rich.sections" type="checkbox"/>
+      <label for="settings.remove.rich.sections">Remove Rich Sections (playables, shorts)</label><br/>
       <br/>
 
       <label for="settings.hide.watched.refresh.rate">Refresh rate for feed clearing (milliseconds)</label>

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -68,7 +68,7 @@
       <label for="settings.hide.shorts">Hide Shorts automatically</label><br/>
 
       <input id="settings.remove.rich.sections" type="checkbox"/>
-      <label for="settings.remove.rich.sections">Remove Rich Sections (playables, shorts)</label><br/>
+      <label for="settings.remove.rich.sections">Remove Rich Sections (shorts, playables, surveys)</label><br/>
       <br/>
 
       <label for="settings.hide.watched.refresh.rate">Refresh rate for feed clearing (milliseconds)</label>

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -237,6 +237,11 @@ function processSections() {
 function removeWatchedAndAddButton() {
     log("Removing watched from feed and adding overlay");
 
+    let richSections = document.querySelectorAll(".ytd-rich-section-renderer");
+    if (removeRichSections) {
+        richSections.forEach(elem => elem.remove());
+    }
+
     let els = document.querySelectorAll(vidQuery());
 
     let hiddenCount = 0;

--- a/subs.js
+++ b/subs.js
@@ -3,6 +3,7 @@ let hideWatched = null;
 let hidePremieres = null;
 let hideShorts = null;
 let intervalId = null;
+let removeRichSections = null;
 
 function isYouTubeWatched(item) {
     let ytWatchedPercentThreshold = settings["settings.mark.watched.youtube.watched"];
@@ -92,6 +93,9 @@ async function initSubs() {
     }
     if (hideShorts == null) {
         hideShorts = settings["settings.hide.shorts"];
+    }
+    if (removeRichSections == null) {
+        removeRichSections = settings["settings.remove.rich.sections"];
     }
 
     buildUI();


### PR DESCRIPTION
Addresses #206 

Removes Rich Shelves entirely, currently found to remove shorts, playables, and Youtube surveys from home and subscriptions feed. 

This is not reversed with the Hide Watched toggle. Due to these elements locking up the discovery of videos below these elements I have chosen to remove them entirely instead of hiding them. 