### PR TITLE
implement feature: Remove Podcast Playlists

### DIFF
--- a/common.js
+++ b/common.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
     "settings.hide.watched.auto.store": true,
     "settings.hide.premieres": false,
     "settings.hide.shorts": false,
+    "settings.remove.podcast.playlists": false,
 };
 
 const SETTINGS_KEY = "settings";

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -68,6 +68,10 @@
       <label for="settings.hide.shorts">Hide Shorts automatically</label><br/>
       <br/>
 
+      <input id="settings.remove.podcast.playlists" type="checkbox"/>
+      <label for="settings.remove.podcast.playlists">Remove Podcast Playlists</label><br/>
+      <br/>
+
       <label for="settings.hide.watched.refresh.rate">Refresh rate for feed clearing (milliseconds)</label>
       <input id="settings.hide.watched.refresh.rate" type="number"/><br/>
       <label for="settings.hide.watched.refresh.rate">(currently works only in "hide watched" state)</label>

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -237,6 +237,17 @@ function processSections() {
 function removeWatchedAndAddButton() {
     log("Removing watched from feed and adding overlay");
 
+    if (removePodcastPlaylists) {
+        let podcastPlaylists = document.querySelectorAll("#content > yt-lockup-view-model > div > div > yt-lockup-metadata-view-model > div.yt-lockup-metadata-view-model__text-container > div > yt-content-metadata-view-model > div:nth-child(3) > span > span > a");
+        podcastPlaylists.forEach(playlist => {
+            const richItem = playlist.closest("ytd-rich-item-renderer");
+            if (richItem) {
+                richItem.remove()
+            }
+        });
+    }
+
+
     let els = document.querySelectorAll(vidQuery());
 
     let hiddenCount = 0;

--- a/subs.js
+++ b/subs.js
@@ -2,6 +2,7 @@ let hidden = [];
 let hideWatched = null;
 let hidePremieres = null;
 let hideShorts = null;
+let removePodcastPlaylists = null;
 let intervalId = null;
 
 function isYouTubeWatched(item) {
@@ -92,6 +93,9 @@ async function initSubs() {
     }
     if (hideShorts == null) {
         hideShorts = settings["settings.hide.shorts"];
+    }
+    if (removePodcastPlaylists == null) {
+        removePodcastPlaylists = settings["settings.remove.podcast.playlists"];
     }
 
     buildUI();


### PR DESCRIPTION
Partially addresses #193 

Similar to issue #206 -> When podcast playlists are displayed on home feed, all videos below them are undiscoverable to the extension. 

For this reason, I have chosen to remove these elements instead of hiding them when the option is enabled.