### PR TITLE
Fix #182: Add option to hide members-only videos

### DIFF
--- a/common.js
+++ b/common.js
@@ -15,6 +15,7 @@ const DEFAULT_SETTINGS = {
     "settings.hide.premieres": false,
     "settings.hide.shorts": false,
     "settings.hide.lives": false,
+    "settings.hide.members.only": false,
 };
 
 const SETTINGS_KEY = "settings";

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -152,6 +152,17 @@
 
                     <div class="setting-item">
                         <div class="setting-info">
+                            <span class="setting-title" id="setting-hide-members-only-title">Hide members-only content</span>
+                            <span class="setting-description" id="setting-hide-members-only-desc">Hide videos that require YouTube channel membership to watch</span>
+                        </div>
+                        <label class="toggle">
+                            <input type="checkbox" id="settings.hide.members.only" aria-labelledby="setting-hide-members-only-title" aria-describedby="setting-hide-members-only-desc">
+                            <span class="toggle-slider"></span>
+                        </label>
+                    </div>
+
+                    <div class="setting-item">
+                        <div class="setting-info">
                             <span class="setting-title">Feed refresh rate</span>
                             <span class="setting-description">How often to check for and hide watched videos (only when "Hide Watched" is active)</span>
                         </div>

--- a/subs.js
+++ b/subs.js
@@ -3,6 +3,7 @@ let hideWatched = null;
 let hidePremieres = null;
 let hideShorts = null;
 let hideLives = null;
+let hideMembersOnly = null;
 let intervalId = null;
 
 function isYouTubeWatched(item) {
@@ -112,6 +113,9 @@ async function initSubs() {
     }
     if (hideLives == null) {
         hideLives = settings["settings.hide.lives"];
+    }
+    if (hideMembersOnly == null) {
+        hideMembersOnly = settings["settings.hide.members.only"];
     }
 
     buildUI();

--- a/videos/Video.js
+++ b/videos/Video.js
@@ -71,6 +71,13 @@ function isLivestream(item) {
     return liveBadge != null;
 }
 
+function isMembersOnly(item) {
+    // Check for membership badge using CSS class (language-independent)
+    // The class yt-badge-shape--membership is used for members-only content
+    let memberBadge = item.containingDiv.querySelector(".yt-badge-shape--membership");
+    return memberBadge != null;
+}
+
 function changeMarkWatchedToMarkUnwatched(item) {
     // find Mark as watched button and change it to Unmark as watched
     let metaDataLine = item.querySelector("#" + METADATA_LINE);
@@ -94,6 +101,10 @@ class Video {
         // Detect livestream first (language-independent via CSS class)
         this.isLivestream = isLivestream(this);
         logDebug("Checking video " + this.videoId + " for livestream: " + this.isLivestream);
+
+        // Detect members-only content (language-independent via CSS class)
+        this.isMembersOnly = isMembersOnly(this);
+        logDebug("Checking video " + this.videoId + " for members-only: " + this.isMembersOnly);
 
         // Only mark as premiere if no duration AND not a livestream
         logDebug("Checking video " + this.videoId + " for premiere: duration = " + this.videoDuration);
@@ -124,7 +135,8 @@ class Video {
                 (hideWatched && this.isStored) ||
                 (hidePremieres && this.isPremiere) ||
                 (hideShorts && this.isShort) ||
-                (hideLives && this.isLivestream)
+                (hideLives && this.isLivestream) ||
+                (hideMembersOnly && this.isMembersOnly)
         );
     }
 


### PR DESCRIPTION
## Summary
- Adds a new setting to hide videos that require YouTube channel membership to watch
- Detection uses the `.yt-badge-shape--membership` CSS class (language-independent)
- Follows the same pattern used for hiding premieres, shorts, and livestreams

## Test plan
- [ ] Load extension in browser
- [ ] Go to YouTube subscriptions page
- [ ] Verify members-only videos appear normally when setting is OFF
- [ ] Enable "Hide members-only content" in extension settings
- [ ] Reload subscriptions page
- [ ] Verify members-only videos are now hidden

Closes #182

🤖 Generated with [Claude Code](https://claude.ai/code)