### PR TITLE
Fix #175: Add option to hide mark as watched button

### DIFF
--- a/common.js
+++ b/common.js
@@ -16,6 +16,7 @@ const DEFAULT_SETTINGS = {
     "settings.hide.shorts": false,
     "settings.hide.lives": false,
     "settings.hide.members.only": false,
+    "settings.hide.mark.watched.button": false,
 };
 
 const SETTINGS_KEY = "settings";

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -163,6 +163,17 @@
 
                     <div class="setting-item">
                         <div class="setting-info">
+                            <span class="setting-title" id="setting-hide-mark-watched-button-title">Hide mark as watched button</span>
+                            <span class="setting-description" id="setting-hide-mark-watched-button-desc">Hide the button to mark individual videos as watched/unwatched</span>
+                        </div>
+                        <label class="toggle">
+                            <input type="checkbox" id="settings.hide.mark.watched.button" aria-labelledby="setting-hide-mark-watched-button-title" aria-describedby="setting-hide-mark-watched-button-desc">
+                            <span class="toggle-slider"></span>
+                        </label>
+                    </div>
+
+                    <div class="setting-item">
+                        <div class="setting-info">
                             <span class="setting-title">Feed refresh rate</span>
                             <span class="setting-description">How often to check for and hide watched videos (only when "Hide Watched" is active)</span>
                         </div>

--- a/videos/SubscriptionsVideo.js
+++ b/videos/SubscriptionsVideo.js
@@ -16,6 +16,11 @@ class SubscriptionVideo extends Video {
     }
 
     addButton() {
+        // Check if button should be hidden
+        if (settings["settings.hide.mark.watched.button"]) {
+            return;
+        }
+
         if (!this.contentDiv) {
             return;
         }


### PR DESCRIPTION
## Summary
- Add new setting `settings.hide.mark.watched.button` (default: false)
- Add UI toggle in Settings page under "Subscriptions Feed" section
- Skip button rendering in `SubscriptionsVideo.addButton()` when setting is enabled

Closes #175

## Test plan
- [ ] Load extension in Chrome/Firefox
- [ ] Go to YouTube subscription feed and verify "Mark as watched" button appears by default
- [ ] Open extension settings and enable "Hide mark as watched button"
- [ ] Save settings and refresh subscription feed
- [ ] Verify button no longer appears on videos
- [ ] Disable setting, save, refresh, and verify button reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)