### PR TITLE
Fix empty Shorts section not hidden when all shorts are hidden

### DIFF
--- a/subs-ui.js
+++ b/subs-ui.js
@@ -277,12 +277,12 @@ function removeWatchedAndAddButton() {
     const gridElement = document.querySelector('ytd-two-column-browse-results-renderer ytd-rich-grid-renderer #contents');
     if (gridElement && isRendered(gridElement)) {
         [...gridElement.querySelectorAll(':scope > ytd-rich-section-renderer')].forEach(richSectionElement => {
-            const contents = richSectionElement.querySelector(':scope > #content > ytd-rich-shelf-renderer > #dismissible > #contents');
+            const contents = richSectionElement.querySelector(':scope > #content > ytd-rich-shelf-renderer > #dismissible #contents');
 
             if (!contents) {
                 return;
             }
-            if (![...contents.childNodes].some(child => isRendered(child))) {
+            if (![...contents.children].some(child => isRendered(child))) {
                 richSectionElement.style.display = 'none';
             }
         });


### PR DESCRIPTION
## Summary
- Fix stale CSS selector in `subs-ui.js` that prevented empty Shorts sections from being hidden after YouTube added an intermediate `#contents-container` wrapper
- Use `children` instead of `childNodes` to avoid `getComputedStyle` errors on text nodes

## Test plan
- [ ] Load extension in Chrome/Firefox
- [ ] Go to `/feed/subscriptions`
- [ ] With "hide shorts" enabled: entire Shorts section (header + items) should be hidden
- [ ] Mark all shorts in a section as watched: entire section should disappear
- [ ] Mark one short as unwatched: section should reappear
- [ ] Verify backwards compatibility with older YouTube layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)