### PR TITLE
Reorganize Subscriptions Feed settings into groups

### DIFF
--- a/pages/settings/settings.css
+++ b/pages/settings/settings.css
@@ -82,6 +82,21 @@
     padding: var(--spacing-md) 0;
 }
 
+/* Settings Sub-group */
+.settings-group + .settings-group {
+    border-top: 2px solid var(--color-border);
+}
+
+.settings-group__title {
+    display: block;
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: var(--spacing-md) var(--spacing-lg) var(--spacing-xs);
+}
+
 /* Setting Item */
 .setting-item {
     display: flex;

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -51,146 +51,162 @@
                 </div>
 
                 <div class="settings-list hidden">
-                    <div class="setting-item">
-                        <div class="setting-info">
-                            <span class="setting-title" id="setting-hide-watched-label-title">Show "Hide Watched" label</span>
-                            <span class="setting-description" id="setting-hide-watched-label-desc">Display the label text next to the hide watched button</span>
+                    <div class="settings-group">
+                        <h3 class="settings-group__title">Anti-Enshittification</h3>
+
+                        <div class="setting-item">
+                            <div class="setting-info">
+                                <span class="setting-title" id="setting-hide-most-relevant-title">Hide Most Relevant section</span>
+                                <span class="setting-description" id="setting-hide-most-relevant-desc">Hide the Most Relevant shelf from subscription feed</span>
+                            </div>
+                            <label class="toggle">
+                                <input type="checkbox" id="settings.hide.most.relevant" aria-labelledby="setting-hide-most-relevant-title" aria-describedby="setting-hide-most-relevant-desc">
+                                <span class="toggle-slider"></span>
+                            </label>
                         </div>
-                        <label class="toggle">
-                            <input type="checkbox" id="settings.hide.watched.label" aria-labelledby="setting-hide-watched-label-title" aria-describedby="setting-hide-watched-label-desc">
-                            <span class="toggle-slider"></span>
-                        </label>
+
+                        <div class="setting-item">
+                            <div class="setting-info">
+                                <span class="setting-title" id="setting-hide-shorts-title">Hide Shorts</span>
+                                <span class="setting-description" id="setting-hide-shorts-desc">Automatically hide YouTube Shorts from your feed</span>
+                            </div>
+                            <label class="toggle">
+                                <input type="checkbox" id="settings.hide.shorts" aria-labelledby="setting-hide-shorts-title" aria-describedby="setting-hide-shorts-desc">
+                                <span class="toggle-slider"></span>
+                            </label>
+                        </div>
                     </div>
 
-                    <div class="setting-item">
-                        <div class="setting-info">
-                            <span class="setting-title" id="setting-hide-watched-all-label-title">Show "Mark all as watched" label</span>
-                            <span class="setting-description" id="setting-hide-watched-all-label-desc">Display the label text next to the mark all button</span>
+                    <div class="settings-group">
+                        <h3 class="settings-group__title">Content Filters</h3>
+
+                        <div class="setting-item">
+                            <div class="setting-info">
+                                <span class="setting-title" id="setting-hide-premieres-title">Hide Premieres</span>
+                                <span class="setting-description" id="setting-hide-premieres-desc">Hide premiere videos until they are available to watch</span>
+                            </div>
+                            <label class="toggle">
+                                <input type="checkbox" id="settings.hide.premieres" aria-labelledby="setting-hide-premieres-title" aria-describedby="setting-hide-premieres-desc">
+                                <span class="toggle-slider"></span>
+                            </label>
                         </div>
-                        <label class="toggle">
-                            <input type="checkbox" id="settings.hide.watched.all.label" aria-labelledby="setting-hide-watched-all-label-title" aria-describedby="setting-hide-watched-all-label-desc">
-                            <span class="toggle-slider"></span>
-                        </label>
+
+                        <div class="setting-item">
+                            <div class="setting-info">
+                                <span class="setting-title" id="setting-hide-lives-title">Hide currently live streams</span>
+                                <span class="setting-description" id="setting-hide-lives-desc">Hide streams while they are live. Once ended, they will appear as regular videos.</span>
+                            </div>
+                            <label class="toggle">
+                                <input type="checkbox" id="settings.hide.lives" aria-labelledby="setting-hide-lives-title" aria-describedby="setting-hide-lives-desc">
+                                <span class="toggle-slider"></span>
+                            </label>
+                        </div>
+
+                        <div class="setting-item">
+                            <div class="setting-info">
+                                <span class="setting-title" id="setting-hide-members-only-title">Hide members-only content</span>
+                                <span class="setting-description" id="setting-hide-members-only-desc">Hide videos that require YouTube channel membership to watch</span>
+                            </div>
+                            <label class="toggle">
+                                <input type="checkbox" id="settings.hide.members.only" aria-labelledby="setting-hide-members-only-title" aria-describedby="setting-hide-members-only-desc">
+                                <span class="toggle-slider"></span>
+                            </label>
+                        </div>
                     </div>
 
-                    <div class="setting-item">
-                        <div class="setting-info">
-                            <span class="setting-title" id="setting-ui-stick-right-title">Stick UI to the right menu</span>
-                            <span class="setting-description" id="setting-ui-stick-right-desc">Position the extension controls on the right side of the page</span>
+                    <div class="settings-group">
+                        <h3 class="settings-group__title">Watched Videos</h3>
+
+                        <div class="setting-item">
+                            <div class="setting-info">
+                                <span class="setting-title" id="setting-hide-watched-default-title">Hide watched by default</span>
+                                <span class="setting-description" id="setting-hide-watched-default-desc">Automatically hide watched videos when loading the subscriptions page</span>
+                            </div>
+                            <label class="toggle">
+                                <input type="checkbox" id="settings.hide.watched.default" aria-labelledby="setting-hide-watched-default-title" aria-describedby="setting-hide-watched-default-desc">
+                                <span class="toggle-slider"></span>
+                            </label>
                         </div>
-                        <label class="toggle">
-                            <input type="checkbox" id="settings.hide.watched.ui.stick.right" aria-labelledby="setting-ui-stick-right-title" aria-describedby="setting-ui-stick-right-desc">
-                            <span class="toggle-slider"></span>
-                        </label>
+
+                        <div class="setting-item">
+                            <div class="setting-info">
+                                <span class="setting-title" id="setting-keep-state-title">Keep hide state through navigation</span>
+                                <span class="setting-description" id="setting-keep-state-desc">Preserve the "Hide Watched" checkbox state when navigating to other pages and back</span>
+                            </div>
+                            <label class="toggle">
+                                <input type="checkbox" id="settings.hide.watched.keep.state" aria-labelledby="setting-keep-state-title" aria-describedby="setting-keep-state-desc">
+                                <span class="toggle-slider"></span>
+                            </label>
+                        </div>
+
+                        <div class="setting-item">
+                            <div class="setting-info">
+                                <span class="setting-title" id="setting-youtube-watched-title">Use YouTube's watched indicator</span>
+                                <span class="setting-description" id="setting-youtube-watched-desc">Mark videos as watched based on YouTube's red progress bar. Requires page reload to apply.</span>
+                            </div>
+                            <label class="toggle">
+                                <input type="checkbox" id="settings.mark.watched.youtube.watched" aria-labelledby="setting-youtube-watched-title" aria-describedby="setting-youtube-watched-desc">
+                                <span class="toggle-slider"></span>
+                            </label>
+                        </div>
+
+                        <div class="setting-item">
+                            <div class="setting-info">
+                                <span class="setting-title">Feed refresh rate</span>
+                                <span class="setting-description">How often to check for and hide watched videos (only when "Hide Watched" is active)</span>
+                            </div>
+                            <div class="input-group">
+                                <input type="number" id="settings.hide.watched.refresh.rate" class="input-number" min="100" step="100">
+                                <span class="input-unit">ms</span>
+                            </div>
+                        </div>
                     </div>
 
-                    <div class="setting-item">
-                        <div class="setting-info">
-                            <span class="setting-title" id="setting-hide-watched-default-title">Hide watched by default</span>
-                            <span class="setting-description" id="setting-hide-watched-default-desc">Automatically hide watched videos when loading the subscriptions page</span>
-                        </div>
-                        <label class="toggle">
-                            <input type="checkbox" id="settings.hide.watched.default" aria-labelledby="setting-hide-watched-default-title" aria-describedby="setting-hide-watched-default-desc">
-                            <span class="toggle-slider"></span>
-                        </label>
-                    </div>
+                    <div class="settings-group">
+                        <h3 class="settings-group__title">Interface</h3>
 
-                    <div class="setting-item">
-                        <div class="setting-info">
-                            <span class="setting-title" id="setting-keep-state-title">Keep hide state through navigation</span>
-                            <span class="setting-description" id="setting-keep-state-desc">Preserve the "Hide Watched" checkbox state when navigating to other pages and back</span>
+                        <div class="setting-item">
+                            <div class="setting-info">
+                                <span class="setting-title" id="setting-hide-watched-label-title">Show "Hide Watched" label</span>
+                                <span class="setting-description" id="setting-hide-watched-label-desc">Display the label text next to the hide watched button</span>
+                            </div>
+                            <label class="toggle">
+                                <input type="checkbox" id="settings.hide.watched.label" aria-labelledby="setting-hide-watched-label-title" aria-describedby="setting-hide-watched-label-desc">
+                                <span class="toggle-slider"></span>
+                            </label>
                         </div>
-                        <label class="toggle">
-                            <input type="checkbox" id="settings.hide.watched.keep.state" aria-labelledby="setting-keep-state-title" aria-describedby="setting-keep-state-desc">
-                            <span class="toggle-slider"></span>
-                        </label>
-                    </div>
 
-                    <div class="setting-item">
-                        <div class="setting-info">
-                            <span class="setting-title" id="setting-youtube-watched-title">Use YouTube's watched indicator</span>
-                            <span class="setting-description" id="setting-youtube-watched-desc">Mark videos as watched based on YouTube's red progress bar. Requires page reload to apply.</span>
+                        <div class="setting-item">
+                            <div class="setting-info">
+                                <span class="setting-title" id="setting-hide-watched-all-label-title">Show "Mark all as watched" label</span>
+                                <span class="setting-description" id="setting-hide-watched-all-label-desc">Display the label text next to the mark all button</span>
+                            </div>
+                            <label class="toggle">
+                                <input type="checkbox" id="settings.hide.watched.all.label" aria-labelledby="setting-hide-watched-all-label-title" aria-describedby="setting-hide-watched-all-label-desc">
+                                <span class="toggle-slider"></span>
+                            </label>
                         </div>
-                        <label class="toggle">
-                            <input type="checkbox" id="settings.mark.watched.youtube.watched" aria-labelledby="setting-youtube-watched-title" aria-describedby="setting-youtube-watched-desc">
-                            <span class="toggle-slider"></span>
-                        </label>
-                    </div>
 
-                    <div class="setting-item">
-                        <div class="setting-info">
-                            <span class="setting-title" id="setting-hide-premieres-title">Hide Premieres</span>
-                            <span class="setting-description" id="setting-hide-premieres-desc">Hide premiere videos until they are available to watch</span>
+                        <div class="setting-item">
+                            <div class="setting-info">
+                                <span class="setting-title" id="setting-ui-stick-right-title">Stick UI to the right menu</span>
+                                <span class="setting-description" id="setting-ui-stick-right-desc">Position the extension controls on the right side of the page</span>
+                            </div>
+                            <label class="toggle">
+                                <input type="checkbox" id="settings.hide.watched.ui.stick.right" aria-labelledby="setting-ui-stick-right-title" aria-describedby="setting-ui-stick-right-desc">
+                                <span class="toggle-slider"></span>
+                            </label>
                         </div>
-                        <label class="toggle">
-                            <input type="checkbox" id="settings.hide.premieres" aria-labelledby="setting-hide-premieres-title" aria-describedby="setting-hide-premieres-desc">
-                            <span class="toggle-slider"></span>
-                        </label>
-                    </div>
 
-                    <div class="setting-item">
-                        <div class="setting-info">
-                            <span class="setting-title" id="setting-hide-shorts-title">Hide Shorts</span>
-                            <span class="setting-description" id="setting-hide-shorts-desc">Automatically hide YouTube Shorts from your feed</span>
-                        </div>
-                        <label class="toggle">
-                            <input type="checkbox" id="settings.hide.shorts" aria-labelledby="setting-hide-shorts-title" aria-describedby="setting-hide-shorts-desc">
-                            <span class="toggle-slider"></span>
-                        </label>
-                    </div>
-
-                    <div class="setting-item">
-                        <div class="setting-info">
-                            <span class="setting-title" id="setting-hide-lives-title">Hide currently live streams</span>
-                            <span class="setting-description" id="setting-hide-lives-desc">Hide streams while they are live. Once ended, they will appear as regular videos.</span>
-                        </div>
-                        <label class="toggle">
-                            <input type="checkbox" id="settings.hide.lives" aria-labelledby="setting-hide-lives-title" aria-describedby="setting-hide-lives-desc">
-                            <span class="toggle-slider"></span>
-                        </label>
-                    </div>
-
-                    <div class="setting-item">
-                        <div class="setting-info">
-                            <span class="setting-title" id="setting-hide-members-only-title">Hide members-only content</span>
-                            <span class="setting-description" id="setting-hide-members-only-desc">Hide videos that require YouTube channel membership to watch</span>
-                        </div>
-                        <label class="toggle">
-                            <input type="checkbox" id="settings.hide.members.only" aria-labelledby="setting-hide-members-only-title" aria-describedby="setting-hide-members-only-desc">
-                            <span class="toggle-slider"></span>
-                        </label>
-                    </div>
-
-                    <div class="setting-item">
-                        <div class="setting-info">
-                            <span class="setting-title" id="setting-hide-most-relevant-title">Hide Most Relevant section</span>
-                            <span class="setting-description" id="setting-hide-most-relevant-desc">Hide the Most Relevant shelf from subscription feed</span>
-                        </div>
-                        <label class="toggle">
-                            <input type="checkbox" id="settings.hide.most.relevant" aria-labelledby="setting-hide-most-relevant-title" aria-describedby="setting-hide-most-relevant-desc">
-                            <span class="toggle-slider"></span>
-                        </label>
-                    </div>
-
-                    <div class="setting-item">
-                        <div class="setting-info">
-                            <span class="setting-title" id="setting-hide-mark-watched-button-title">Hide mark as watched button</span>
-                            <span class="setting-description" id="setting-hide-mark-watched-button-desc">Hide the button to mark individual videos as watched/unwatched</span>
-                        </div>
-                        <label class="toggle">
-                            <input type="checkbox" id="settings.hide.mark.watched.button" aria-labelledby="setting-hide-mark-watched-button-title" aria-describedby="setting-hide-mark-watched-button-desc">
-                            <span class="toggle-slider"></span>
-                        </label>
-                    </div>
-
-                    <div class="setting-item">
-                        <div class="setting-info">
-                            <span class="setting-title">Feed refresh rate</span>
-                            <span class="setting-description">How often to check for and hide watched videos (only when "Hide Watched" is active)</span>
-                        </div>
-                        <div class="input-group">
-                            <input type="number" id="settings.hide.watched.refresh.rate" class="input-number" min="100" step="100">
-                            <span class="input-unit">ms</span>
+                        <div class="setting-item">
+                            <div class="setting-info">
+                                <span class="setting-title" id="setting-hide-mark-watched-button-title">Hide mark as watched button</span>
+                                <span class="setting-description" id="setting-hide-mark-watched-button-desc">Hide the button to mark individual videos as watched/unwatched</span>
+                            </div>
+                            <label class="toggle">
+                                <input type="checkbox" id="settings.hide.mark.watched.button" aria-labelledby="setting-hide-mark-watched-button-title" aria-describedby="setting-hide-mark-watched-button-desc">
+                                <span class="toggle-slider"></span>
+                            </label>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Groups the 13 flat settings in the Subscriptions Feed card into 4 visual sub-groups: **Anti-Enshittification**, **Content Filters**, **Watched Videos**, and **Interface**
- Reorders settings by importance (hide toggles fighting YouTube's algorithmic additions first, cosmetic interface settings last)
- Adds `.settings-group` / `.settings-group__title` CSS styles for group separators and headings

## Test plan
- [ ] Open `pages/settings/settings.html` directly in browser to visually confirm grouping and headings
- [ ] Load extension in Chrome → open settings → verify all toggles still save/load correctly
- [ ] `npx jest` passes (171 tests, no JS changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)