### PR TITLE
Fix false "Settings synced" notification on every reload

### DIFF
--- a/settingsLoader.js
+++ b/settingsLoader.js
@@ -25,8 +25,9 @@ function migrateSettings(loadedSettings) {
 // Helper to compare settings objects
 function settingsChanged(oldSettings, newSettings) {
     if (!newSettings) return false;
+    const merged = {...DEFAULT_SETTINGS, ...newSettings};
     for (let key in DEFAULT_SETTINGS) {
-        if (oldSettings[key] !== newSettings[key]) return true;
+        if (oldSettings[key] !== merged[key]) return true;
     }
     // Detect new keys from newer extension versions
     for (let key in newSettings) {


### PR DESCRIPTION
## Summary
- Fixes #229
- `settingsChanged()` compared fully-merged settings (defaults + local cache) against raw sync storage that lacks newer keys (e.g. `settings.hide.most.relevant`), causing `false !== undefined` to always return `true` and show the notification on every page reload
- Fix: merge `DEFAULT_SETTINGS` into `newSettings` before comparing, so missing keys resolve to their defaults instead of `undefined`

## Test plan
- [ ] Load extension in Chrome/Firefox
- [ ] Open YouTube subscriptions page and reload — notification should NOT appear
- [ ] Change a setting (or manually edit sync storage) — notification SHOULD appear
- [ ] `npx jest` — all 171 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)