### PR TITLE
Exempt Music Mixes from Hide Watched

### DIFF
--- a/tests/unit/Video.test.js
+++ b/tests/unit/Video.test.js
@@ -300,6 +300,21 @@ describe('Video.js', () => {
             expect(result.shouldHide).toBe(false);
         });
 
+        test('manually marking a mix as watched does not trigger hide', () => {
+            global.watchedVideos = {};
+            global.hideWatched = true;
+            const context = loadSubscriptionsVideo();
+            const div = createVideoDiv('/watch?v=abc12345678&list=RDabc12345678&start_radio=1');
+            context.__testDiv = div;
+            const vm = require('vm');
+            const result = vm.runInContext(
+                '(function() { var v = new Video(__testDiv); v.markWatched(); return { hidden: v.containingDiv.style.display === "none", isMix: v.isMix }; })()',
+                context
+            );
+            expect(result.isMix).toBe(true);
+            expect(result.hidden).toBe(false);
+        });
+
         test('watched non-mix video is still hidden when hideWatched is true', () => {
             const result = createVideo(
                 '/watch?v=abc12345678',

--- a/videos/Video.js
+++ b/videos/Video.js
@@ -152,12 +152,12 @@ class Video {
     markWatched() {
         changeMarkWatchedToMarkUnwatched(this.containingDiv);
 
-        if (hideWatched) {
+        this.isStored = true;
+
+        if (this.shouldHide()) {
             this.hide();
             processSections();
         }
-
-        this.isStored = true;
 
         watchVideo(this.videoId);
         syncWatchedVideos();


### PR DESCRIPTION
## Summary
- Detect YouTube Music Mixes via `start_radio=1` in the video URL (`isMix` property on `Video`)
- Exempt mixes from the "Hide Watched" check in `shouldHide()` so they remain visible even when their underlying video was previously watched
- Add 5 unit tests covering mix detection and hide exemption

Fixes #238

## Test plan
- [x] `npx jest` — all 179 tests pass
- [ ] Load extension in Chrome/Firefox dev mode
- [ ] Navigate to `/feed/subscriptions`, click "Mixes" category filter
- [ ] With "Hide Watched" ON: verify mixes are NOT hidden even though their video was previously watched
- [ ] Verify regular watched videos are still correctly hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)