### PR TITLE
Fix Firefox layout bug with compact mark-watched button

### DIFF
--- a/subs.css
+++ b/subs.css
@@ -98,7 +98,7 @@ ytd-grid-video-renderer.style-scope.ytd-grid-renderer:hover .subs-btn-mark-watch
 }
 
 /* Compact layout: positioned below the triple dots menu */
-.yt-lockup-metadata-view-model__menu-button {
+.subs-btn-compact-wrapper {
   position: relative;
 }
 

--- a/videos/SubscriptionsVideo.js
+++ b/videos/SubscriptionsVideo.js
@@ -56,9 +56,18 @@ class SubscriptionVideo extends Video {
                 ? verticalDiv.querySelector(".yt-lockup-metadata-view-model__menu-button")
                 : null;
             if (menuButtonDiv) {
-                // Compact layout: place inside the menu button area (next to triple dots)
+                // Compact layout: place inside a wrapper to avoid position:relative on flex item (Firefox bug)
                 container.classList.add("subs-btn-container--compact");
-                menuButtonDiv.appendChild(container);
+                let wrapper = menuButtonDiv.querySelector(".subs-btn-compact-wrapper");
+                if (!wrapper) {
+                    wrapper = document.createElement("div");
+                    wrapper.classList.add("subs-btn-compact-wrapper");
+                    while (menuButtonDiv.firstChild) {
+                        wrapper.appendChild(menuButtonDiv.firstChild);
+                    }
+                    menuButtonDiv.appendChild(wrapper);
+                }
+                wrapper.appendChild(container);
             } else {
                 // Default layout: insert after metadata div
                 let metadataDiv = verticalDiv.querySelector(":scope > .yt-lockup-view-model__metadata");


### PR DESCRIPTION
## Summary
- Fixes #244 — compact mode mark-watched button caused squished metadata and mispositioned button in Firefox
- Root cause: `position: relative` on a flex item (`__menu-button`) triggers different sizing behavior in Firefox vs Chrome
- Fix: wrap the menu button contents in an inner `div.subs-btn-compact-wrapper` that holds `position: relative`, keeping the flex item itself unstyled

## Test plan
- [ ] Firefox: compact mode + short title — metadata fills full thumbnail width
- [ ] Firefox: compact mode + long title — button positioned below dots menu
- [ ] Chrome: no regression in compact or default mode
- [ ] 4-column and 1-column grid layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)