### PR TITLE
Add option to hide collab videos from non-subscribed channels

### DIFF
--- a/common.js
+++ b/common.js
@@ -346,3 +346,7 @@ function getCurrentPage() {
 
     return "";
 }
+
+function isSubscriptionsPage() {
+    return getCurrentPage() === "/feed/subscriptions";
+}

--- a/common.js
+++ b/common.js
@@ -16,6 +16,7 @@ const DEFAULT_SETTINGS = {
     "settings.hide.shorts": false,
     "settings.hide.lives": false,
     "settings.hide.members.only": false,
+    "settings.hide.collabs.unsubscribed": false,
     "settings.hide.most.relevant": false,
     "settings.hide.mark.watched.button": false,
     "settings.mark.watched.button.compact": true,

--- a/manifest.json
+++ b/manifest.json
@@ -38,6 +38,7 @@
         "common.js",
         "settingsLoader.js",
         "queries.js",
+        "subscriptionCache.js",
         "videos/Video.js",
         "videos/SubscriptionsVideo.js",
         "subs-ui.js",
@@ -53,7 +54,7 @@
   ],
   "web_accessible_resources": [
     {
-      "resources": ["images/*"],
+      "resources": ["images/*", "pageContext.js"],
       "matches": ["<all_urls>"]
     }
   ],

--- a/manifest.json
+++ b/manifest.json
@@ -55,7 +55,7 @@
   "web_accessible_resources": [
     {
       "resources": ["images/*", "pageContext.js"],
-      "matches": ["<all_urls>"]
+      "matches": ["*://*.youtube.com/*"]
     }
   ],
   "background": {

--- a/pageContext.js
+++ b/pageContext.js
@@ -1,0 +1,141 @@
+// This script runs in the PAGE context (not content script isolated world).
+// It can access Polymer .data properties on YouTube's custom elements.
+// Results are stored as data-* attributes on DOM elements for the content script to read.
+
+(function() {
+    // === Subscription cache ===
+    function scrapeGuideEntries() {
+        const ids = [];
+        document.querySelectorAll('ytd-guide-entry-renderer').forEach(entry => {
+            try {
+                const browseId = entry.data?.navigationEndpoint?.browseEndpoint?.browseId;
+                if (browseId && browseId.startsWith('UC')) ids.push(browseId);
+            } catch (e) {}
+        });
+        return ids;
+    }
+
+    function findExpandButton(iconType) {
+        for (const entry of document.querySelectorAll('ytd-guide-entry-renderer')) {
+            try {
+                if (entry.data?.icon?.iconType === iconType) {
+                    const section = entry.closest('ytd-guide-section-renderer');
+                    const hasChannels = section && Array.from(
+                        section.querySelectorAll('ytd-guide-entry-renderer')
+                    ).some(e => {
+                        const id = e.data?.navigationEndpoint?.browseEndpoint?.browseId;
+                        return id && id.startsWith('UC');
+                    });
+                    if (hasChannels) return entry;
+                }
+            } catch (e) {}
+        }
+        return null;
+    }
+
+    function waitForPopulatedEntries(minExpected, maxAttempts, intervalMs) {
+        return new Promise(resolve => {
+            let attempts = 0;
+            function check() {
+                const ids = scrapeGuideEntries();
+                attempts++;
+                if (ids.length >= minExpected || attempts >= maxAttempts) {
+                    resolve(ids);
+                } else {
+                    setTimeout(check, intervalMs);
+                }
+            }
+            check();
+        });
+    }
+
+    async function buildAndStoreSubscriptionCache() {
+        let ids = scrapeGuideEntries();
+
+        const showMoreBtn = findExpandButton('EXPAND_CAIRO');
+        if (showMoreBtn) {
+            showMoreBtn.click();
+            const initialCount = ids.length;
+            ids = await waitForPopulatedEntries(initialCount + 1, 20, 250);
+            const showFewerBtn = findExpandButton('COLLAPSE_CAIRO');
+            if (showFewerBtn) showFewerBtn.click();
+        }
+
+        document.documentElement.dataset.ytBetterSubsCache = JSON.stringify(ids);
+    }
+
+    // === Collab video poster tagging ===
+    function tagCollabRenderers() {
+        document.querySelectorAll('ytd-rich-item-renderer').forEach(renderer => {
+            if (renderer.dataset.posterChannelId) return;
+            try {
+                const data = renderer.data;
+                if (!data) return;
+                const listItems = data.content?.lockupViewModel?.metadata
+                    ?.lockupMetadataViewModel?.image?.avatarStackViewModel
+                    ?.rendererContext?.commandContext?.onTap?.innertubeCommand
+                    ?.showDialogCommand?.panelLoadingStrategy?.inlineContent
+                    ?.dialogViewModel?.customContent?.listViewModel?.listItems;
+                if (listItems && listItems.length > 0) {
+                    const posterId = listItems[0]?.listItemViewModel
+                        ?.rendererContext?.commandContext?.onTap?.innertubeCommand
+                        ?.browseEndpoint?.browseId;
+                    if (posterId) {
+                        renderer.dataset.posterChannelId = posterId;
+                    }
+                }
+            } catch (e) {}
+        });
+    }
+
+    // Wait for guide entries to have .data, then build cache
+    function waitForGuideAndBuild() {
+        for (const entry of document.querySelectorAll('ytd-guide-entry-renderer')) {
+            if (entry.data?.navigationEndpoint) {
+                buildAndStoreSubscriptionCache();
+                return;
+            }
+        }
+        const guide = document.querySelector('ytd-guide-renderer #sections');
+        if (guide) {
+            const observer = new MutationObserver(() => {
+                for (const entry of document.querySelectorAll('ytd-guide-entry-renderer')) {
+                    if (entry.data?.navigationEndpoint) {
+                        observer.disconnect();
+                        buildAndStoreSubscriptionCache();
+                        return;
+                    }
+                }
+            });
+            observer.observe(guide, { childList: true, subtree: true });
+        } else {
+            setTimeout(waitForGuideAndBuild, 1000);
+        }
+    }
+
+    // === Init ===
+    waitForGuideAndBuild();
+    tagCollabRenderers();
+
+    // Re-tag periodically (covers .data populated after DOM insertion)
+    setInterval(tagCollabRenderers, 2000);
+
+    // Observe for new video renderers
+    function observeGrid() {
+        const grid = document.querySelector('ytd-rich-grid-renderer');
+        if (grid) {
+            new MutationObserver(() => tagCollabRenderers()).observe(grid, { childList: true, subtree: true });
+        } else {
+            setTimeout(observeGrid, 1000);
+        }
+    }
+    observeGrid();
+
+    // YouTube SPA navigation
+    document.addEventListener('yt-navigate-finish', () => {
+        tagCollabRenderers();
+        if (!document.documentElement.dataset.ytBetterSubsCache) {
+            waitForGuideAndBuild();
+        }
+    });
+})();

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -112,6 +112,17 @@
                                 <span class="toggle-slider"></span>
                             </label>
                         </div>
+
+                        <div class="setting-item">
+                            <div class="setting-info">
+                                <span class="setting-title" id="setting-hide-collabs-title">Hide collaboration videos from non-subscribed channels <span style="font-size: 0.7em; padding: 1px 6px; border-radius: 4px; background: #f0ad4e; color: #fff; vertical-align: middle; font-weight: 600;">Experimental</span></span>
+                                <span class="setting-description" id="setting-hide-collabs-desc">Hide videos where the uploader is a channel you're not subscribed to (shown because of a tagged collaborator you follow)</span>
+                            </div>
+                            <label class="toggle">
+                                <input type="checkbox" id="settings.hide.collabs.unsubscribed" aria-labelledby="setting-hide-collabs-title" aria-describedby="setting-hide-collabs-desc">
+                                <span class="toggle-slider"></span>
+                            </label>
+                        </div>
                     </div>
 
                     <div class="settings-group">

--- a/subs-ui.js
+++ b/subs-ui.js
@@ -327,7 +327,7 @@ function removeUI() {
 }
 
 function rebuildUI() {
-    if (getCurrentPage() === "/feed/subscriptions") {
+    if (isSubscriptionsPage()) {
         try {
             removeUI();
             buildUI();

--- a/subs.js
+++ b/subs.js
@@ -127,7 +127,7 @@ async function initSubs() {
         hideMostRelevant = settings["settings.hide.most.relevant"];
     }
 
-    if (hideCollabsUnsubscribed) {
+    if (hideCollabsUnsubscribed && getCurrentPage() === "/feed/subscriptions") {
         buildSubscriptionCache();
     }
 

--- a/subs.js
+++ b/subs.js
@@ -4,6 +4,7 @@ let hidePremieres = null;
 let hideShorts = null;
 let hideLives = null;
 let hideMembersOnly = null;
+let hideCollabsUnsubscribed = null;
 let hideMostRelevant = null;
 let intervalId = null;
 
@@ -119,8 +120,15 @@ async function initSubs() {
     if (hideMembersOnly == null) {
         hideMembersOnly = settings["settings.hide.members.only"];
     }
+    if (hideCollabsUnsubscribed == null) {
+        hideCollabsUnsubscribed = settings["settings.hide.collabs.unsubscribed"];
+    }
     if (hideMostRelevant == null) {
         hideMostRelevant = settings["settings.hide.most.relevant"];
+    }
+
+    if (hideCollabsUnsubscribed) {
+        buildSubscriptionCache();
     }
 
     buildUI();

--- a/subs.js
+++ b/subs.js
@@ -127,7 +127,7 @@ async function initSubs() {
         hideMostRelevant = settings["settings.hide.most.relevant"];
     }
 
-    if (hideCollabsUnsubscribed && getCurrentPage() === "/feed/subscriptions") {
+    if (hideCollabsUnsubscribed && isSubscriptionsPage()) {
         buildSubscriptionCache();
     }
 

--- a/subscriptionCache.js
+++ b/subscriptionCache.js
@@ -1,0 +1,48 @@
+let _subscribedChannelIds = null;
+let _pageContextInjected = false;
+
+// Inject pageContext.js into the page's main world to access Polymer data.
+// CSP blocks inline scripts, so we use an external file via web_accessible_resources.
+function _injectPageContextScript() {
+    if (_pageContextInjected) return;
+    _pageContextInjected = true;
+
+    const script = document.createElement('script');
+    script.src = brwsr.runtime.getURL('pageContext.js');
+    document.documentElement.appendChild(script);
+    script.onload = () => script.remove();
+}
+
+async function buildSubscriptionCache() {
+    if (_subscribedChannelIds !== null) return;
+    _subscribedChannelIds = new Set();
+
+    _injectPageContextScript();
+
+    // Poll for result from pageContext.js (stored in DOM data attribute)
+    let cacheData = null;
+    for (let i = 0; i < 20; i++) {
+        await new Promise(r => setTimeout(r, 500));
+        cacheData = document.documentElement.dataset.ytBetterSubsCache;
+        if (cacheData) break;
+    }
+
+    if (cacheData) {
+        try {
+            const ids = JSON.parse(cacheData);
+            for (const id of ids) {
+                _subscribedChannelIds.add(id);
+            }
+            log("Subscription cache built: " + _subscribedChannelIds.size + " channels");
+        } catch (e) {
+            logWarn("Failed to parse subscription cache: " + e.message);
+        }
+    } else {
+        logWarn("Subscription cache data not available");
+    }
+}
+
+function isSubscribedToChannel(channelId) {
+    if (!channelId || !_subscribedChannelIds || _subscribedChannelIds.size === 0) return true;
+    return _subscribedChannelIds.has(channelId);
+}

--- a/subscriptionCache.js
+++ b/subscriptionCache.js
@@ -14,8 +14,7 @@ function _injectPageContextScript() {
 }
 
 async function buildSubscriptionCache() {
-    if (_subscribedChannelIds !== null) return;
-    _subscribedChannelIds = new Set();
+    if (_subscribedChannelIds !== null && _subscribedChannelIds.size > 0) return;
 
     _injectPageContextScript();
 
@@ -30,15 +29,20 @@ async function buildSubscriptionCache() {
     if (cacheData) {
         try {
             const ids = JSON.parse(cacheData);
-            for (const id of ids) {
-                _subscribedChannelIds.add(id);
+            if (ids.length > 0) {
+                _subscribedChannelIds = new Set(ids);
+                log("Subscription cache built: " + _subscribedChannelIds.size + " channels");
+            } else {
+                _subscribedChannelIds = null;
+                logWarn("Subscription cache returned empty, will retry");
             }
-            log("Subscription cache built: " + _subscribedChannelIds.size + " channels");
         } catch (e) {
+            _subscribedChannelIds = null;
             logWarn("Failed to parse subscription cache: " + e.message);
         }
     } else {
-        logWarn("Subscription cache data not available");
+        _subscribedChannelIds = null;
+        logWarn("Subscription cache data not available, will retry");
     }
 }
 

--- a/tests/helpers/load-source.js
+++ b/tests/helpers/load-source.js
@@ -158,6 +158,9 @@ function loadVideo() {
         hideShorts: global.hideShorts,
         hideLives: global.hideLives,
         hideMembersOnly: global.hideMembersOnly,
+        hideCollabsUnsubscribed: global.hideCollabsUnsubscribed,
+        isSubscribedToChannel: global.isSubscribedToChannel || (() => true),
+        getCurrentPage: global.getCurrentPage || (() => ''),
         watchVideo: global.watchVideo,
         unwatchVideo: global.unwatchVideo,
         syncWatchedVideos: global.syncWatchedVideos,
@@ -172,6 +175,7 @@ function loadVideo() {
     global.getVideoDuration = context.getVideoDuration;
     global.isLivestream = context.isLivestream;
     global.isMembersOnly = context.isMembersOnly;
+    global.getPosterChannelId = context.getPosterChannelId;
     global.changeMarkWatchedToMarkUnwatched = context.changeMarkWatchedToMarkUnwatched;
     global.Video = context.Video;
 
@@ -225,6 +229,9 @@ function loadSubscriptionsVideo() {
         hideShorts: global.hideShorts,
         hideLives: global.hideLives,
         hideMembersOnly: global.hideMembersOnly,
+        hideCollabsUnsubscribed: global.hideCollabsUnsubscribed,
+        isSubscribedToChannel: global.isSubscribedToChannel || (() => true),
+        getCurrentPage: global.getCurrentPage || (() => ''),
         watchVideo: global.watchVideo,
         unwatchVideo: global.unwatchVideo,
         syncWatchedVideos: global.syncWatchedVideos,
@@ -251,6 +258,7 @@ function loadSubscriptionsVideo() {
     global.getVideoDuration = context.getVideoDuration;
     global.isLivestream = context.isLivestream;
     global.isMembersOnly = context.isMembersOnly;
+    global.getPosterChannelId = context.getPosterChannelId;
     global.changeMarkWatchedToMarkUnwatched = context.changeMarkWatchedToMarkUnwatched;
     global.Video = context.Video;
     global.SubscriptionVideo = context.SubscriptionVideo;

--- a/tests/helpers/load-source.js
+++ b/tests/helpers/load-source.js
@@ -106,6 +106,7 @@ function loadCommon() {
     global.syncWatchedVideos = context.syncWatchedVideos;
     global.clearOldestVideos = context.clearOldestVideos;
     global.getCurrentPage = context.getCurrentPage;
+    global.isSubscriptionsPage = context.isSubscriptionsPage;
     global.lastSyncUpdate = context.lastSyncUpdate;
     global.lastSyncError = context.lastSyncError;
     global.encodeTimestamp = context.encodeTimestamp;
@@ -161,6 +162,7 @@ function loadVideo() {
         hideCollabsUnsubscribed: global.hideCollabsUnsubscribed,
         isSubscribedToChannel: global.isSubscribedToChannel || (() => true),
         getCurrentPage: global.getCurrentPage || (() => ''),
+        isSubscriptionsPage: global.isSubscriptionsPage || (() => false),
         watchVideo: global.watchVideo,
         unwatchVideo: global.unwatchVideo,
         syncWatchedVideos: global.syncWatchedVideos,
@@ -232,6 +234,7 @@ function loadSubscriptionsVideo() {
         hideCollabsUnsubscribed: global.hideCollabsUnsubscribed,
         isSubscribedToChannel: global.isSubscribedToChannel || (() => true),
         getCurrentPage: global.getCurrentPage || (() => ''),
+        isSubscriptionsPage: global.isSubscriptionsPage || (() => false),
         watchVideo: global.watchVideo,
         unwatchVideo: global.unwatchVideo,
         syncWatchedVideos: global.syncWatchedVideos,
@@ -369,6 +372,7 @@ function loadSubsUI() {
         collapseSectionChanged: global.collapseSectionChanged,
         loadMoreVideos: global.loadMoreVideos,
         getCurrentPage: global.getCurrentPage,
+        isSubscriptionsPage: global.isSubscriptionsPage,
         isRendered: global.isRendered,
         hideMostRelevant: global.hideMostRelevant
     });

--- a/tests/integration/real-dom.test.js
+++ b/tests/integration/real-dom.test.js
@@ -219,6 +219,7 @@ describe('Real YouTube DOM - YouTube Watched Detection', () => {
         global.loadMoreVideos = jest.fn();
         global.isRendered = jest.fn(() => true);
         global.getCurrentPage = jest.fn(() => '/feed/subscriptions');
+        global.isSubscriptionsPage = jest.fn(() => true);
         global.SubscriptionVideo = jest.fn();
         global.sectionDismissableQuery = jest.fn();
         global.sectionContentsQuery = jest.fn();

--- a/tests/unit/Video.test.js
+++ b/tests/unit/Video.test.js
@@ -327,6 +327,147 @@ describe('Video.js', () => {
         });
     });
 
+    describe('collaboration detection via Video constructor', () => {
+        const { loadSubscriptionsVideo } = require('../helpers/load-source');
+        const vm = require('vm');
+
+        function createCollabVideoDiv(hasAvatarStack, href = '/watch?v=abc12345678') {
+            const avatarStackHtml = hasAvatarStack
+                ? '<yt-avatar-stack-view-model></yt-avatar-stack-view-model>'
+                : '<div class="single-avatar"></div>';
+            document.body.innerHTML = `
+                <div id="container">
+                    <a id="video-title" href="${href}">Title</a>
+                    <div class="yt-badge-shape__text">3:45</div>
+                    ${avatarStackHtml}
+                </div>
+            `;
+            return document.getElementById('container');
+        }
+
+        function makeVideo(hasAvatarStack, opts = {}) {
+            global.watchedVideos = opts.watchedVideos || {};
+            global.hideWatched = opts.hideWatched || false;
+            global.hideCollabsUnsubscribed = opts.hideCollabsUnsubscribed || false;
+            global.isSubscribedToChannel = opts.isSubscribedToChannel || (() => true);
+            global.getCurrentPage = opts.getCurrentPage || (() => '/feed/subscriptions');
+            const context = loadSubscriptionsVideo();
+            const div = createCollabVideoDiv(hasAvatarStack);
+            context.__testDiv = div;
+            return vm.runInContext(
+                '(function() { var v = new Video(__testDiv); return { isCollaboration: v.isCollaboration, shouldHide: v.shouldHide() }; })()',
+                context
+            );
+        }
+
+        test('isCollaboration is true when yt-avatar-stack-view-model present', () => {
+            const result = makeVideo(true);
+            expect(result.isCollaboration).toBe(true);
+        });
+
+        test('isCollaboration is false when no avatar stack', () => {
+            const result = makeVideo(false);
+            expect(result.isCollaboration).toBe(false);
+        });
+
+        test('collab video not hidden when setting is off', () => {
+            const result = makeVideo(true, {
+                hideCollabsUnsubscribed: false,
+                isSubscribedToChannel: () => false
+            });
+            expect(result.isCollaboration).toBe(true);
+            expect(result.shouldHide).toBe(false);
+        });
+
+        test('collab video hidden when setting on, not subscribed to poster, on subs page', () => {
+            const result = makeVideo(true, {
+                hideCollabsUnsubscribed: true,
+                isSubscribedToChannel: () => false,
+                getCurrentPage: () => '/feed/subscriptions'
+            });
+            expect(result.shouldHide).toBe(true);
+        });
+
+        test('collab video not hidden when subscribed to poster', () => {
+            const result = makeVideo(true, {
+                hideCollabsUnsubscribed: true,
+                isSubscribedToChannel: () => true,
+                getCurrentPage: () => '/feed/subscriptions'
+            });
+            expect(result.shouldHide).toBe(false);
+        });
+
+        test('collab video not hidden on non-subscription pages', () => {
+            const result = makeVideo(true, {
+                hideCollabsUnsubscribed: true,
+                isSubscribedToChannel: () => false,
+                getCurrentPage: () => '/'
+            });
+            expect(result.shouldHide).toBe(false);
+        });
+
+        test('collab video not hidden on channel page', () => {
+            const result = makeVideo(true, {
+                hideCollabsUnsubscribed: true,
+                isSubscribedToChannel: () => false,
+                getCurrentPage: () => '/@SomeChannel'
+            });
+            expect(result.shouldHide).toBe(false);
+        });
+
+        test('non-collab video not hidden even with setting on', () => {
+            const result = makeVideo(false, {
+                hideCollabsUnsubscribed: true,
+                isSubscribedToChannel: () => false,
+                getCurrentPage: () => '/feed/subscriptions'
+            });
+            expect(result.shouldHide).toBe(false);
+        });
+    });
+
+    describe('getPosterChannelId', () => {
+        test('returns null when no data-poster-channel-id attribute', () => {
+            document.body.innerHTML = `
+                <ytd-rich-item-renderer>
+                    <div id="container">
+                        <a id="video-title" href="/watch?v=abc12345678">Title</a>
+                        <div class="yt-badge-shape__text">3:45</div>
+                    </div>
+                </ytd-rich-item-renderer>
+            `;
+            const video = { containingDiv: document.getElementById('container'), _posterChannelId: undefined };
+            const result = getPosterChannelId(video);
+            expect(result).toBeNull();
+        });
+
+        test('reads data-poster-channel-id from parent ytd-rich-item-renderer', () => {
+            document.body.innerHTML = `
+                <ytd-rich-item-renderer data-poster-channel-id="UCXuqSBlHAE6Xw-yeJA0Tunw">
+                    <div id="container">
+                        <a id="video-title" href="/watch?v=abc12345678">Title</a>
+                    </div>
+                </ytd-rich-item-renderer>
+            `;
+            const video = { containingDiv: document.getElementById('container'), _posterChannelId: undefined };
+            const result = getPosterChannelId(video);
+            expect(result).toBe('UCXuqSBlHAE6Xw-yeJA0Tunw');
+        });
+
+        test('caches result after first call', () => {
+            document.body.innerHTML = `
+                <ytd-rich-item-renderer data-poster-channel-id="UC12345">
+                    <div id="container"></div>
+                </ytd-rich-item-renderer>
+            `;
+            const video = { containingDiv: document.getElementById('container'), _posterChannelId: undefined };
+            getPosterChannelId(video);
+            expect(video._posterChannelId).toBe('UC12345');
+            // Second call should return cached value
+            document.querySelector('ytd-rich-item-renderer').removeAttribute('data-poster-channel-id');
+            expect(getPosterChannelId(video)).toBe('UC12345');
+        });
+    });
+
     // Video class tests are skipped because JS classes in vm.runInContext
     // cannot be instantiated from outside the context. These would need
     // a different testing approach (e.g., bundling or different module system).

--- a/tests/unit/Video.test.js
+++ b/tests/unit/Video.test.js
@@ -453,7 +453,7 @@ describe('Video.js', () => {
             expect(result).toBe('UCXuqSBlHAE6Xw-yeJA0Tunw');
         });
 
-        test('caches result after first call', () => {
+        test('caches non-null result after first call', () => {
             document.body.innerHTML = `
                 <ytd-rich-item-renderer data-poster-channel-id="UC12345">
                     <div id="container"></div>
@@ -462,9 +462,22 @@ describe('Video.js', () => {
             const video = { containingDiv: document.getElementById('container'), _posterChannelId: undefined };
             getPosterChannelId(video);
             expect(video._posterChannelId).toBe('UC12345');
-            // Second call should return cached value
+            // Second call should return cached value even if attribute removed
             document.querySelector('ytd-rich-item-renderer').removeAttribute('data-poster-channel-id');
             expect(getPosterChannelId(video)).toBe('UC12345');
+        });
+
+        test('does not cache null - allows re-check when attribute appears later', () => {
+            document.body.innerHTML = `
+                <ytd-rich-item-renderer>
+                    <div id="container"></div>
+                </ytd-rich-item-renderer>
+            `;
+            const video = { containingDiv: document.getElementById('container'), _posterChannelId: undefined };
+            expect(getPosterChannelId(video)).toBeNull();
+            // Attribute added later (by pageContext.js)
+            document.querySelector('ytd-rich-item-renderer').dataset.posterChannelId = 'UCabc';
+            expect(getPosterChannelId(video)).toBe('UCabc');
         });
     });
 

--- a/tests/unit/Video.test.js
+++ b/tests/unit/Video.test.js
@@ -350,7 +350,7 @@ describe('Video.js', () => {
             global.hideWatched = opts.hideWatched || false;
             global.hideCollabsUnsubscribed = opts.hideCollabsUnsubscribed || false;
             global.isSubscribedToChannel = opts.isSubscribedToChannel || (() => true);
-            global.getCurrentPage = opts.getCurrentPage || (() => '/feed/subscriptions');
+            global.isSubscriptionsPage = opts.isSubscriptionsPage !== undefined ? opts.isSubscriptionsPage : (() => true);
             const context = loadSubscriptionsVideo();
             const div = createCollabVideoDiv(hasAvatarStack);
             context.__testDiv = div;
@@ -383,7 +383,7 @@ describe('Video.js', () => {
             const result = makeVideo(true, {
                 hideCollabsUnsubscribed: true,
                 isSubscribedToChannel: () => false,
-                getCurrentPage: () => '/feed/subscriptions'
+                isSubscriptionsPage: () => true
             });
             expect(result.shouldHide).toBe(true);
         });
@@ -392,7 +392,7 @@ describe('Video.js', () => {
             const result = makeVideo(true, {
                 hideCollabsUnsubscribed: true,
                 isSubscribedToChannel: () => true,
-                getCurrentPage: () => '/feed/subscriptions'
+                isSubscriptionsPage: () => true
             });
             expect(result.shouldHide).toBe(false);
         });
@@ -401,7 +401,7 @@ describe('Video.js', () => {
             const result = makeVideo(true, {
                 hideCollabsUnsubscribed: true,
                 isSubscribedToChannel: () => false,
-                getCurrentPage: () => '/'
+                isSubscriptionsPage: () => false
             });
             expect(result.shouldHide).toBe(false);
         });
@@ -410,7 +410,7 @@ describe('Video.js', () => {
             const result = makeVideo(true, {
                 hideCollabsUnsubscribed: true,
                 isSubscribedToChannel: () => false,
-                getCurrentPage: () => '/@SomeChannel'
+                isSubscriptionsPage: () => false
             });
             expect(result.shouldHide).toBe(false);
         });
@@ -419,7 +419,7 @@ describe('Video.js', () => {
             const result = makeVideo(false, {
                 hideCollabsUnsubscribed: true,
                 isSubscribedToChannel: () => false,
-                getCurrentPage: () => '/feed/subscriptions'
+                isSubscriptionsPage: () => true
             });
             expect(result.shouldHide).toBe(false);
         });

--- a/tests/unit/subscriptionCache.test.js
+++ b/tests/unit/subscriptionCache.test.js
@@ -1,0 +1,76 @@
+/**
+ * Tests for subscriptionCache.js
+ * isSubscribedToChannel logic (the cache building itself requires page context)
+ */
+
+const vm = require('vm');
+const { loadSource, loadUtil } = require('../helpers/load-source');
+
+describe('subscriptionCache.js', () => {
+    let cacheContext;
+
+    beforeEach(() => {
+        loadUtil();
+
+        // Mock brwsr.runtime.getURL
+        global.brwsr = {
+            runtime: {
+                getURL: jest.fn(path => `chrome-extension://test-id/${path}`)
+            }
+        };
+
+        cacheContext = loadSource('subscriptionCache.js', {
+            log: global.log,
+            logDebug: global.logDebug,
+            logWarn: global.logWarn,
+            logError: global.logError,
+            brwsr: global.brwsr
+        });
+    });
+
+    // Helper to set the cache from inside the VM context
+    function setCache(ids) {
+        vm.runInContext(
+            `_subscribedChannelIds = new Set(${JSON.stringify(ids)})`,
+            cacheContext
+        );
+    }
+
+    describe('isSubscribedToChannel', () => {
+        test('returns true (fail-open) when channelId is null', () => {
+            expect(cacheContext.isSubscribedToChannel(null)).toBe(true);
+        });
+
+        test('returns true (fail-open) when channelId is empty string', () => {
+            expect(cacheContext.isSubscribedToChannel('')).toBe(true);
+        });
+
+        test('returns true (fail-open) when channelId is undefined', () => {
+            expect(cacheContext.isSubscribedToChannel(undefined)).toBe(true);
+        });
+
+        test('returns true (fail-open) when cache is not built (null)', () => {
+            expect(cacheContext.isSubscribedToChannel('UCtest123')).toBe(true);
+        });
+
+        test('returns true (fail-open) when cache is empty set', () => {
+            setCache([]);
+            expect(cacheContext.isSubscribedToChannel('UCtest123')).toBe(true);
+        });
+
+        test('returns true when channel is in cache', () => {
+            setCache(['UCabc', 'UCdef', 'UCghi']);
+            expect(cacheContext.isSubscribedToChannel('UCdef')).toBe(true);
+        });
+
+        test('returns false when channel is not in cache', () => {
+            setCache(['UCabc', 'UCdef', 'UCghi']);
+            expect(cacheContext.isSubscribedToChannel('UCxyz')).toBe(false);
+        });
+
+        test('returns false for similar but non-matching channel ID', () => {
+            setCache(['UCabc123']);
+            expect(cacheContext.isSubscribedToChannel('UCabc124')).toBe(false);
+        });
+    });
+});

--- a/videos/Video.js
+++ b/videos/Video.js
@@ -78,6 +78,19 @@ function isMembersOnly(item) {
     return memberBadge != null;
 }
 
+function getPosterChannelId(video) {
+    if (video._posterChannelId !== undefined) return video._posterChannelId;
+    video._posterChannelId = null;
+
+    // pageContext.js (running in page world) tags collab renderers with data-poster-channel-id
+    const renderer = video.containingDiv.closest('ytd-rich-item-renderer');
+    if (renderer && renderer.dataset.posterChannelId) {
+        video._posterChannelId = renderer.dataset.posterChannelId;
+    }
+
+    return video._posterChannelId;
+}
+
 function changeMarkWatchedToMarkUnwatched(item) {
     // find Mark as watched button and change it to Unmark as watched
     let metaDataLine = item.querySelector("#" + METADATA_LINE);
@@ -123,6 +136,9 @@ class Video {
 
         this.isMix = videoHref != null && videoHref.includes("start_radio=1");
         logDebug("Checking video " + this.videoId + " for mix: " + this.isMix);
+
+        this.isCollaboration = this.containingDiv.querySelector('yt-avatar-stack-view-model') !== null;
+        this._posterChannelId = undefined; // lazy-loaded
     }
 
     hasButton() {
@@ -139,7 +155,8 @@ class Video {
                 (hidePremieres && this.isPremiere) ||
                 (hideShorts && this.isShort) ||
                 (hideLives && this.isLivestream) ||
-                (hideMembersOnly && this.isMembersOnly)
+                (hideMembersOnly && this.isMembersOnly) ||
+                (hideCollabsUnsubscribed && this.isCollaboration && !isSubscribedToChannel(getPosterChannelId(this)))
         );
     }
 

--- a/videos/Video.js
+++ b/videos/Video.js
@@ -156,7 +156,7 @@ class Video {
                 (hideShorts && this.isShort) ||
                 (hideLives && this.isLivestream) ||
                 (hideMembersOnly && this.isMembersOnly) ||
-                (hideCollabsUnsubscribed && this.isCollaboration && !isSubscribedToChannel(getPosterChannelId(this)))
+                (hideCollabsUnsubscribed && this.isCollaboration && getCurrentPage() === "/feed/subscriptions" && !isSubscribedToChannel(getPosterChannelId(this)))
         );
     }
 

--- a/videos/Video.js
+++ b/videos/Video.js
@@ -79,16 +79,20 @@ function isMembersOnly(item) {
 }
 
 function getPosterChannelId(video) {
-    if (video._posterChannelId !== undefined) return video._posterChannelId;
-    video._posterChannelId = null;
+    // Return cached non-null ID
+    if (video._posterChannelId !== undefined && video._posterChannelId !== null) {
+        return video._posterChannelId;
+    }
 
     // pageContext.js (running in page world) tags collab renderers with data-poster-channel-id
     const renderer = video.containingDiv.closest('ytd-rich-item-renderer');
     if (renderer && renderer.dataset.posterChannelId) {
         video._posterChannelId = renderer.dataset.posterChannelId;
+        return video._posterChannelId;
     }
 
-    return video._posterChannelId;
+    // Don't memoize absence - pageContext.js tags asynchronously, allow re-check
+    return null;
 }
 
 function changeMarkWatchedToMarkUnwatched(item) {

--- a/videos/Video.js
+++ b/videos/Video.js
@@ -160,7 +160,7 @@ class Video {
                 (hideShorts && this.isShort) ||
                 (hideLives && this.isLivestream) ||
                 (hideMembersOnly && this.isMembersOnly) ||
-                (hideCollabsUnsubscribed && this.isCollaboration && getCurrentPage() === "/feed/subscriptions" && !isSubscribedToChannel(getPosterChannelId(this)))
+                (hideCollabsUnsubscribed && this.isCollaboration && isSubscriptionsPage() && !isSubscribedToChannel(getPosterChannelId(this)))
         );
     }
 


### PR DESCRIPTION
## Summary
- Adds a new **experimental** setting to hide collaboration videos from the subscription feed when the uploader is a channel you're not subscribed to (the video only appeared because a tagged collaborator you follow)
- Uses YouTube's Polymer data model via an injected page-context script to extract poster channel IDs and match against the user's subscription list
- Only applies on the `/feed/subscriptions` page — other pages (home, channel, etc.) are unaffected

Closes #241

## How it works
1. **Detection**: Collaboration videos identified by `yt-avatar-stack-view-model` element in the DOM
2. **Poster identification**: `pageContext.js` runs in the page's main world to access Polymer `.data` properties, extracts the poster's channel ID from the collaborator dialog data, and tags `ytd-rich-item-renderer` elements with `data-poster-channel-id` attributes
3. **Subscription cache**: On init, programmatically expands the sidebar "Show more" to scrape all subscribed channel IDs, then collapses it back
4. **Filtering**: `shouldHide()` checks if the poster channel ID is in the subscription set; if not, hides the video
5. **Fail-open**: If Polymer data extraction fails or subscription cache is empty, videos are never hidden (no false positives)

## Test plan
- [ ] Load extension on `/feed/subscriptions` with setting OFF — no behavior change
- [ ] Enable "Hide collaboration videos from non-subscribed channels" in settings, reload
- [ ] Collab videos from non-subscribed uploaders are hidden
- [ ] Collab videos from subscribed uploaders remain visible
- [ ] Non-collab videos unaffected
- [ ] Homepage / channel pages show all collab videos normally
- [ ] Console shows "Subscription cache built: N channels" at info log level

🤖 Generated with [Claude Code](https://claude.com/claude-code)