### PR TITLE
update duration container name for premiere - fixes #257

### DIFF
--- a/tests/fixtures/channel-videos.html
+++ b/tests/fixtures/channel-videos.html
@@ -16,7 +16,7 @@
                                 <ytd-thumbnail-overlay-time-status-renderer class="style-scope ytd-thumbnail">
                                     <div class="thumbnail-overlay-badge-shape style-scope ytd-thumbnail-overlay-time-status-renderer">
                                         <badge-shape class="yt-badge-shape yt-badge-shape--thumbnail-default yt-badge-shape--thumbnail-badge">
-                                            <div class="yt-badge-shape__text">15:42</div>
+                                            <div class="ytBadgeShapeText">15:42</div>
                                         </badge-shape>
                                     </div>
                                 </ytd-thumbnail-overlay-time-status-renderer>
@@ -63,7 +63,7 @@
                                 <ytd-thumbnail-overlay-time-status-renderer class="style-scope ytd-thumbnail">
                                     <div class="thumbnail-overlay-badge-shape style-scope ytd-thumbnail-overlay-time-status-renderer">
                                         <badge-shape class="yt-badge-shape yt-badge-shape--thumbnail-default yt-badge-shape--thumbnail-badge">
-                                            <div class="yt-badge-shape__text">22:10</div>
+                                            <div class="ytBadgeShapeText">22:10</div>
                                         </badge-shape>
                                     </div>
                                 </ytd-thumbnail-overlay-time-status-renderer>
@@ -136,7 +136,7 @@
                                 <ytd-thumbnail-overlay-time-status-renderer class="style-scope ytd-thumbnail">
                                     <div class="thumbnail-overlay-badge-shape style-scope ytd-thumbnail-overlay-time-status-renderer">
                                         <badge-shape class="yt-badge-shape yt-badge-shape--thumbnail-live yt-badge-shape--thumbnail-badge">
-                                            <div class="yt-badge-shape__text">LIVE</div>
+                                            <div class="ytBadgeShapeText">LIVE</div>
                                         </badge-shape>
                                     </div>
                                 </ytd-thumbnail-overlay-time-status-renderer>

--- a/tests/fixtures/subscription-feed-2026.html
+++ b/tests/fixtures/subscription-feed-2026.html
@@ -41,7 +41,7 @@
                                   <div class="ytThumbnailBottomOverlayViewModelBadgeContainer ytThumbnailBottomOverlayViewModelBadgeContainerLarge">
                                     <yt-thumbnail-badge-view-model class="ytThumbnailBadgeViewModelHost ytThumbnailBottomOverlayViewModelBadge">
                                       <badge-shape class="yt-badge-shape yt-badge-shape--thumbnail-default yt-badge-shape--thumbnail-badge yt-badge-shape--typography">
-                                        <div class="yt-badge-shape__text">39:36</div>
+                                        <div class="ytBadgeShapeText">39:36</div>
                                       </badge-shape>
                                     </yt-thumbnail-badge-view-model>
                                   </div>
@@ -98,7 +98,7 @@
                                   <div class="ytThumbnailBottomOverlayViewModelBadgeContainer ytThumbnailBottomOverlayViewModelBadgeContainerLarge">
                                     <yt-thumbnail-badge-view-model class="ytThumbnailBadgeViewModelHost ytThumbnailBottomOverlayViewModelBadge">
                                       <badge-shape class="yt-badge-shape yt-badge-shape--thumbnail-default yt-badge-shape--thumbnail-badge yt-badge-shape--typography">
-                                        <div class="yt-badge-shape__text">11:20</div>
+                                        <div class="ytBadgeShapeText">11:20</div>
                                       </badge-shape>
                                     </yt-thumbnail-badge-view-model>
                                   </div>
@@ -241,7 +241,7 @@
                       <div class="ytThumbnailBottomOverlayViewModelBadgeContainer ytThumbnailBottomOverlayViewModelBadgeContainerLarge">
                         <yt-thumbnail-badge-view-model class="ytThumbnailBadgeViewModelHost ytThumbnailBottomOverlayViewModelBadge">
                           <badge-shape class="yt-badge-shape yt-badge-shape--thumbnail-default yt-badge-shape--thumbnail-badge yt-badge-shape--typography">
-                            <div class="yt-badge-shape__text">1:52</div>
+                            <div class="ytBadgeShapeText">1:52</div>
                           </badge-shape>
                         </yt-thumbnail-badge-view-model>
                       </div>
@@ -288,7 +288,7 @@
                       <div class="ytThumbnailBottomOverlayViewModelBadgeContainer ytThumbnailBottomOverlayViewModelBadgeContainerLarge">
                         <yt-thumbnail-badge-view-model class="ytThumbnailBadgeViewModelHost ytThumbnailBottomOverlayViewModelBadge">
                           <badge-shape class="yt-badge-shape yt-badge-shape--thumbnail-live yt-badge-shape--thumbnail-badge yt-badge-shape--typography">
-                            <div class="yt-badge-shape__text">LIVE</div>
+                            <div class="ytBadgeShapeText">LIVE</div>
                           </badge-shape>
                         </yt-thumbnail-badge-view-model>
                       </div>
@@ -335,12 +335,12 @@
                       <div class="ytThumbnailBottomOverlayViewModelBadgeContainer ytThumbnailBottomOverlayViewModelBadgeContainerLarge">
                         <yt-thumbnail-badge-view-model class="ytThumbnailBadgeViewModelHost ytThumbnailBottomOverlayViewModelBadge">
                           <badge-shape class="yt-badge-shape yt-badge-shape--membership yt-badge-shape--thumbnail-badge yt-badge-shape--typography">
-                            <div class="yt-badge-shape__text">Members only</div>
+                            <div class="ytBadgeShapeText">Members only</div>
                           </badge-shape>
                         </yt-thumbnail-badge-view-model>
                         <yt-thumbnail-badge-view-model class="ytThumbnailBadgeViewModelHost ytThumbnailBottomOverlayViewModelBadge">
                           <badge-shape class="yt-badge-shape yt-badge-shape--thumbnail-default yt-badge-shape--thumbnail-badge yt-badge-shape--typography">
-                            <div class="yt-badge-shape__text">25:00</div>
+                            <div class="ytBadgeShapeText">25:00</div>
                           </badge-shape>
                         </yt-thumbnail-badge-view-model>
                       </div>

--- a/tests/fixtures/subscription-feed.html
+++ b/tests/fixtures/subscription-feed.html
@@ -1,4 +1,4 @@
-<!-- YouTube Subscription Feed Mock Structure -->
+<!-- YouTube Subscription Feed Mock Structure - pre 2026-04 -->
 <div id="page-manager">
     <ytd-browse page-subtype="subscriptions">
         <div id="primary">

--- a/tests/fixtures/video-card.html
+++ b/tests/fixtures/video-card.html
@@ -4,7 +4,7 @@
         <a id="video-title" href="/watch?v=dQw4w9WgXcQ">
             <span>Test Video Title</span>
         </a>
-        <div class="yt-badge-shape__text">10:30</div>
+        <div class="ytBadgeShapeText">10:30</div>
     </div>
 </div>
 
@@ -25,7 +25,7 @@
             <span>Members Only Video</span>
         </a>
         <div class="yt-badge-shape--membership">Members only</div>
-        <div class="yt-badge-shape__text">15:00</div>
+        <div class="ytBadgeShapeText">15:00</div>
     </div>
 </div>
 

--- a/tests/integration/real-dom.test.js
+++ b/tests/integration/real-dom.test.js
@@ -140,7 +140,7 @@ describe('Real YouTube DOM - Duration & Badge Detection', () => {
         items = document.querySelectorAll(vidQuery());
     });
 
-    test('getVideoDuration() extracts duration from yt-badge-shape__text', () => {
+    test('getVideoDuration() extracts duration from ytBadgeShapeText', () => {
         // items[0] = Video 1 (39:36)
         const mockItem = { containingDiv: items[0] };
         const duration = getVideoDuration(mockItem);
@@ -314,7 +314,7 @@ describe('Real YouTube DOM - Video Type Classification', () => {
     test('members-only: isMembersOnly when has membership badge', () => {
         const props = classifyItem(items[6]); // Video 7 (members)
         expect(props.members).toBe(true);
-        // Note: getVideoDuration() uses querySelector(".yt-badge-shape__text") which
+        // Note: getVideoDuration() uses querySelector(".ytBadgeShapeText") which
         // returns the FIRST match — the "Members only" badge text, not the duration.
         // Since "Members only" doesn't contain ":", duration is null.
         // This means members-only videos with the membership badge before the duration

--- a/tests/unit/Video.test.js
+++ b/tests/unit/Video.test.js
@@ -155,7 +155,7 @@ describe('Video.js', () => {
         test('gets duration from old layout badge', () => {
             document.body.innerHTML = `
                 <div id="container">
-                    <div class="yt-badge-shape__text">10:30</div>
+                    <div class="ytBadgeShapeText">10:30</div>
                 </div>
             `;
             const video = { containingDiv: document.getElementById('container') };
@@ -192,7 +192,7 @@ describe('Video.js', () => {
         test('returns null when badge text does not contain colon', () => {
             document.body.innerHTML = `
                 <div id="container">
-                    <div class="yt-badge-shape__text">LIVE</div>
+                    <div class="ytBadgeShapeText">LIVE</div>
                 </div>
             `;
             const video = { containingDiv: document.getElementById('container') };
@@ -250,7 +250,7 @@ describe('Video.js', () => {
             document.body.innerHTML = `
                 <div id="container">
                     <a id="video-title" href="${href}">Title</a>
-                    <div class="yt-badge-shape__text">3:45</div>
+                    <div class="ytBadgeShapeText">3:45</div>
                 </div>
             `;
             return document.getElementById('container');
@@ -338,7 +338,7 @@ describe('Video.js', () => {
             document.body.innerHTML = `
                 <div id="container">
                     <a id="video-title" href="${href}">Title</a>
-                    <div class="yt-badge-shape__text">3:45</div>
+                    <div class="ytBadgeShapeText">3:45</div>
                     ${avatarStackHtml}
                 </div>
             `;
@@ -431,7 +431,7 @@ describe('Video.js', () => {
                 <ytd-rich-item-renderer>
                     <div id="container">
                         <a id="video-title" href="/watch?v=abc12345678">Title</a>
-                        <div class="yt-badge-shape__text">3:45</div>
+                        <div class="ytBadgeShapeText">3:45</div>
                     </div>
                 </ytd-rich-item-renderer>
             `;

--- a/videos/Video.js
+++ b/videos/Video.js
@@ -43,8 +43,9 @@ function getVideoId(item) {
 }
 
 function getVideoDuration(item) {
+
     // Try old layout selector
-    let durationDiv = item.containingDiv.querySelector(".yt-badge-shape__text");
+    let durationDiv = item.containingDiv.querySelector(".ytBadgeShapeText");
     if ((durationDiv != null) && (durationDiv.textContent.includes(":"))) {
         return durationDiv.textContent;
     }
@@ -59,6 +60,12 @@ function getVideoDuration(item) {
                 return badgeText;
             }
         }
+    }
+
+    // Try older layout selector pre 2026-04
+    durationDiv = item.containingDiv.querySelector(".yt-badge-shape__text");
+    if ((durationDiv != null) && (durationDiv.textContent.includes(":"))) {
+        return durationDiv.textContent;
     }
 
     return null;


### PR DESCRIPTION
Fix 'duration' container name (yt code changed) - fixes #257

NOTE only tested in firefox/us-en